### PR TITLE
feat(multiplex): add ScopedWAL implementation with concurrent WAL benchmarks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,27 @@ func TestConfig() *Config {
 	}
 }
 
+// MultiplexTestConfig returns a configuration that can be used for testing
+// the multiplex node implementation (plural replication mode).
+func MultiplexTestConfig(
+	repl DataReplicationConfig,
+	userScopes map[string][]string,
+) *Config {
+	return &Config{
+		BaseConfig:      MultiplexTestBaseConfig(repl, userScopes),
+		RPC:             TestRPCConfig(),
+		GRPC:            TestGRPCConfig(),
+		P2P:             TestP2PConfig(),
+		Mempool:         TestMempoolConfig(),
+		StateSync:       TestStateSyncConfig(),
+		BlockSync:       TestBlockSyncConfig(),
+		Consensus:       TestConsensusConfig(),
+		Storage:         TestStorageConfig(),
+		TxIndex:         TestTxIndexConfig(),
+		Instrumentation: TestInstrumentationConfig(),
+	}
+}
+
 // SetRoot sets the RootDir for all Config structs.
 func (cfg *Config) SetRoot(root string) *Config {
 	cfg.BaseConfig.RootDir = root
@@ -134,6 +155,28 @@ func (cfg *Config) SetRoot(root string) *Config {
 	cfg.Mempool.RootDir = root
 	cfg.Consensus.RootDir = root
 	return cfg
+}
+
+func (cfg *Config) SetListenAddresses(
+	p2pListenAddr string,
+	rpcListenAddr string,
+	grpcListenAddr string,
+	grpcPrivListenAddr string,
+) *Config {
+	cfg.P2P.ListenAddress = p2pListenAddr
+	cfg.RPC.ListenAddress = rpcListenAddr
+	cfg.GRPC.ListenAddress = grpcListenAddr
+	cfg.GRPC.Privileged.ListenAddress = grpcPrivListenAddr
+	return cfg
+}
+
+func (cfg *Config) GetListenAddresses() map[string]string {
+	return map[string]string{
+		"P2P":      cfg.P2P.ListenAddress,
+		"RPC":      cfg.RPC.ListenAddress,
+		"GRPC":     cfg.GRPC.ListenAddress,
+		"GRPCPriv": cfg.GRPC.Privileged.ListenAddress,
+	}
 }
 
 // ValidateBasic performs basic validation (checking param bounds, etc.) and

--- a/internal/consensus/wal.go
+++ b/internal/consensus/wal.go
@@ -108,6 +108,19 @@ func NewWAL(walFile string, groupOptions ...func(*auto.Group)) (*BaseWAL, error)
 	return wal, nil
 }
 
+// NewWALWithParams creates a BaseWAL pointer with provided parameters
+func NewWALWithParams(
+	group *auto.Group,
+	enc *WALEncoder,
+	flushInterval time.Duration,
+) *BaseWAL {
+	return &BaseWAL{
+		group:         group,
+		enc:           enc,
+		flushInterval: flushInterval,
+	}
+}
+
 // SetFlushInterval allows us to override the periodic flush interval for the WAL.
 func (wal *BaseWAL) SetFlushInterval(i time.Duration) {
 	wal.flushInterval = i
@@ -311,7 +324,7 @@ func (enc *WALEncoder) Encode(v *TimedWALMessage) error {
 
 	data, err := proto.Marshal(&pv)
 	if err != nil {
-		panic(fmt.Errorf("encode timed wall message failure: %w", err))
+		panic(fmt.Errorf("encode timed wal message failure: %w", err))
 	}
 
 	crc := crc32.Checksum(data, crc32c)

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -24,8 +24,6 @@ func ResetTestRootWithChainID(testName string, chainID string) *config.Config {
 
 	baseConfig := config.DefaultBaseConfig()
 	genesisFilePath := filepath.Join(rootDir, baseConfig.Genesis)
-	privKeyFilePath := filepath.Join(rootDir, baseConfig.PrivValidatorKey)
-	privStateFilePath := filepath.Join(rootDir, baseConfig.PrivValidatorState)
 
 	if !cmtos.FileExists(genesisFilePath) {
 		if chainID == "" {
@@ -34,12 +32,25 @@ func ResetTestRootWithChainID(testName string, chainID string) *config.Config {
 		testGenesis := fmt.Sprintf(testGenesisFmt, chainID)
 		cmtos.MustWriteFile(genesisFilePath, []byte(testGenesis), 0o644)
 	}
-	// we always overwrite the priv val
-	cmtos.MustWriteFile(privKeyFilePath, []byte(testPrivValidatorKey), 0o644)
-	cmtos.MustWriteFile(privStateFilePath, []byte(testPrivValidatorState), 0o644)
+
+	// We always overwrite the priv val
+	ResetTestPrivValidator(rootDir, baseConfig)
 
 	config := config.TestConfig().SetRoot(rootDir)
 	return config
+}
+
+func ResetTestPrivValidator(rootDir string, conf config.BaseConfig) {
+	privKeyFilePath := filepath.Join(rootDir, conf.PrivValidatorKey)
+	privStateFilePath := filepath.Join(rootDir, conf.PrivValidatorState)
+
+	cmtos.MustWriteFile(privKeyFilePath, []byte(testPrivValidatorKey), 0o644)
+	cmtos.MustWriteFile(privStateFilePath, []byte(testPrivValidatorState), 0o644)
+}
+
+func ResetTestPrivValidatorFiles(privKeyFilePath string, privStateFilePath string) {
+	cmtos.MustWriteFile(privKeyFilePath, []byte(testPrivValidatorKey), 0o644)
+	cmtos.MustWriteFile(privStateFilePath, []byte(testPrivValidatorState), 0o644)
 }
 
 var testGenesisFmt = `{

--- a/multiplex/autofile.go
+++ b/multiplex/autofile.go
@@ -1,0 +1,61 @@
+package multiplex
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	auto "github.com/cometbft/cometbft/internal/autofile"
+	"github.com/cometbft/cometbft/libs/service"
+)
+
+// ScopedGroup embeds a group instance and adds a scope hash
+type ScopedGroup struct {
+	ScopeHash string
+	*auto.Group
+}
+
+// ----------------------------------------------------------------------------
+// Scoped instance getters
+
+// GetScopedGroup tries to find a group instance in the group multiplex using its scope hash
+func GetScopedGroup(
+	multiplex MultiplexGroup,
+	userScopeHash string,
+) (*ScopedGroup, error) {
+	scopeHash, err := hex.DecodeString(userScopeHash)
+	if err != nil || len(scopeHash) != sha256.Size {
+		return nil, fmt.Errorf("incorrect scope hash for autofile group multiplex, got %v bytes, expected %v bytes", len(scopeHash), sha256.Size)
+	}
+
+	if scopedGroup, ok := multiplex[userScopeHash]; ok {
+		return scopedGroup, nil
+	}
+
+	return nil, fmt.Errorf("could not find autofile group in multiplex using scope hash %s", scopeHash)
+}
+
+// OpenGroup creates a new scoped Group with head at headPath. It returns an error if
+// it fails to open head file.
+func OpenScopedGroup(
+	scopeHash string,
+	headPath string,
+	groupOptions ...func(*auto.Group),
+) (*ScopedGroup, error) {
+	baseGroup, err := auto.OpenGroup(headPath, groupOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("could not open scoped autofile group with scope hash %s: %w", scopeHash, err)
+	}
+
+	g := &ScopedGroup{
+		ScopeHash: scopeHash,
+		Group:     baseGroup,
+	}
+
+	for _, option := range groupOptions {
+		option(g.Group)
+	}
+
+	g.BaseService = *service.NewBaseService(nil, "ScopedGroup", g)
+	return g, nil
+}

--- a/multiplex/autofile.go
+++ b/multiplex/autofile.go
@@ -35,7 +35,7 @@ func GetScopedGroup(
 	return nil, fmt.Errorf("could not find autofile group in multiplex using scope hash %s", scopeHash)
 }
 
-// OpenGroup creates a new scoped Group with head at headPath. It returns an error if
+// OpenScopedGroup creates a new scoped Group with head at headPath. It returns an error if
 // it fails to open head file.
 func OpenScopedGroup(
 	scopeHash string,

--- a/multiplex/config.go
+++ b/multiplex/config.go
@@ -1,0 +1,116 @@
+package multiplex
+
+import (
+	cfg "github.com/cometbft/cometbft/config"
+)
+
+// ScopedUserConfig embeds UserConfig and computes SHA256 hashes
+// by pairing user addresses and individual scopes such that every
+// combination of user address and scope can be referred to by hash
+type ScopedUserConfig struct {
+	cfg.UserConfig
+
+	// userAddresses contains addresses (20 bytes hex) by which state is replicated.
+	// This property is populated automatically and should not be modified.
+	userAddresses []string
+
+	// userScopeHashes maps user addresses to the complete list of SHA256 hashes
+	// computed from pairing said user address with the scopes as listed above.
+	// This property is populated automatically and should not be modified.
+	userScopeHashes map[string][]string
+}
+
+// computeUserScopeHashes uses DefaultScopeHashProvider to populate the config
+// instance's userScopeHashes and userAddresses fields.
+func (c *ScopedUserConfig) computeUserScopeHashes() error {
+	if c.Replication == cfg.SingularReplicationMode() {
+		return nil
+	}
+
+	c.userScopeHashes = map[string][]string{}
+	if scopeRegistry, err := DefaultScopeHashProvider(&c.UserConfig); err == nil {
+		c.userScopeHashes = scopeRegistry.ScopeHashes
+	} else {
+		return err
+	}
+
+	c.userAddresses = make([]string, len(c.UserScopes))
+	for userAddress := range c.UserScopes {
+		c.userAddresses = append(c.userAddresses, userAddress)
+	}
+
+	return nil
+}
+
+// GetScopeHashes returns a slice of the flattened user scope hashes
+func (c *ScopedUserConfig) GetScopeHashes() []string {
+	var allHashes []string
+	for _, scopeHashes := range c.userScopeHashes {
+		allHashes = append(allHashes, scopeHashes...)
+	}
+
+	return allHashes
+}
+
+// ----------------------------------------------------------------------------
+// Builders
+
+// NewUserConfig returns a new pointer to a ScopedUserConfig object.
+func NewUserConfig(
+	repl cfg.DataReplicationConfig,
+	userScopes map[string][]string,
+	startListenPort int,
+) *ScopedUserConfig {
+	config := &ScopedUserConfig{
+		UserConfig: cfg.UserConfig{
+			Replication: cfg.PluralReplicationMode(),
+			UserScopes:  userScopes,
+			ListenPort:  startListenPort,
+		},
+	}
+
+	config.computeUserScopeHashes()
+	return config
+}
+
+// NewScopedUserConfig returns a scoped configuration for UserConfig.
+func NewScopedUserConfig(userScopes map[string][]string, startListenPort int) *ScopedUserConfig {
+	config := NewUserConfig(
+		cfg.PluralReplicationMode(),
+		userScopes,
+		startListenPort,
+	)
+	return config
+}
+
+// ----------------------------------------------------------------------------
+// Testing builders
+
+// TestUserConfig returns a basic user configuration for testing a CometBFT node.
+func TestUserConfig() ScopedUserConfig {
+	return ScopedUserConfig{
+		UserConfig: cfg.DefaultUserConfig(),
+	}
+}
+
+// TestScopedUserConfig returns a scoped configuration for UserConfig.
+func TestScopedUserConfig(userScopes map[string][]string) ScopedUserConfig {
+	configScopes := make(map[string][]string, len(userScopes))
+	if len(userScopes) == 0 {
+		configScopes = map[string][]string{
+			"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"Default"},
+			"FF1410CEEB411E55487701C4FEE65AACE7115DC0": {"Default"},
+		}
+	} else {
+		for userAddress, scopes := range userScopes {
+			configScopes[userAddress] = scopes
+		}
+	}
+
+	cfg := NewUserConfig(
+		cfg.PluralReplicationMode(),
+		configScopes,
+		30001,
+	)
+	return *cfg
+}

--- a/multiplex/config.go
+++ b/multiplex/config.go
@@ -1,14 +1,14 @@
 package multiplex
 
 import (
-	cfg "github.com/cometbft/cometbft/config"
+	cmtcfg "github.com/cometbft/cometbft/config"
 )
 
 // ScopedUserConfig embeds UserConfig and computes SHA256 hashes
 // by pairing user addresses and individual scopes such that every
 // combination of user address and scope can be referred to by hash
 type ScopedUserConfig struct {
-	cfg.UserConfig
+	cmtcfg.UserConfig
 
 	// userAddresses contains addresses (20 bytes hex) by which state is replicated.
 	// This property is populated automatically and should not be modified.
@@ -23,7 +23,7 @@ type ScopedUserConfig struct {
 // computeUserScopeHashes uses DefaultScopeHashProvider to populate the config
 // instance's userScopeHashes and userAddresses fields.
 func (c *ScopedUserConfig) computeUserScopeHashes() error {
-	if c.Replication == cfg.SingularReplicationMode() {
+	if c.Replication == cmtcfg.SingularReplicationMode() {
 		return nil
 	}
 
@@ -57,13 +57,13 @@ func (c *ScopedUserConfig) GetScopeHashes() []string {
 
 // NewUserConfig returns a new pointer to a ScopedUserConfig object.
 func NewUserConfig(
-	repl cfg.DataReplicationConfig,
+	repl cmtcfg.DataReplicationConfig,
 	userScopes map[string][]string,
 	startListenPort int,
 ) *ScopedUserConfig {
 	config := &ScopedUserConfig{
-		UserConfig: cfg.UserConfig{
-			Replication: cfg.PluralReplicationMode(),
+		UserConfig: cmtcfg.UserConfig{
+			Replication: cmtcfg.PluralReplicationMode(),
 			UserScopes:  userScopes,
 			ListenPort:  startListenPort,
 		},
@@ -76,7 +76,7 @@ func NewUserConfig(
 // NewScopedUserConfig returns a scoped configuration for UserConfig.
 func NewScopedUserConfig(userScopes map[string][]string, startListenPort int) *ScopedUserConfig {
 	config := NewUserConfig(
-		cfg.PluralReplicationMode(),
+		cmtcfg.PluralReplicationMode(),
 		userScopes,
 		startListenPort,
 	)
@@ -89,7 +89,7 @@ func NewScopedUserConfig(userScopes map[string][]string, startListenPort int) *S
 // TestUserConfig returns a basic user configuration for testing a CometBFT node.
 func TestUserConfig() ScopedUserConfig {
 	return ScopedUserConfig{
-		UserConfig: cfg.DefaultUserConfig(),
+		UserConfig: cmtcfg.DefaultUserConfig(),
 	}
 }
 
@@ -108,7 +108,7 @@ func TestScopedUserConfig(userScopes map[string][]string) ScopedUserConfig {
 	}
 
 	cfg := NewUserConfig(
-		cfg.PluralReplicationMode(),
+		cmtcfg.PluralReplicationMode(),
 		configScopes,
 		30001,
 	)

--- a/multiplex/db_test.go
+++ b/multiplex/db_test.go
@@ -1,0 +1,135 @@
+package multiplex
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
+)
+
+// ----------------------------------------------------------------------------
+// Benchmarks
+
+func benchmarkDBWrite(b *testing.B, dbs []dbm.DB, numDatabases int) {
+	b.Helper()
+
+	// Creates a thread-safe rand instance
+	randomizer := cmtrand.NewRand()
+
+	// Mocks a key-value pair
+	key := []byte(`key`)
+	data := []byte(`value`)
+
+	b.SetParallelism(numDatabases) // 1 proc per DB
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Every iteration should perform a write in DB
+		for pb.Next() {
+			// cmtrand is thread-safe
+			dbIdx := randomizer.Intn(numDatabases)
+			dbs[dbIdx].Set(key, data)
+		}
+	})
+}
+
+// ----------------------------------------------------------------------------
+// cometbft-db MemDB implementation benchmarks
+
+func BenchmarkMultiDBSetKey1K(b *testing.B) {
+	numDatabases := 1000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetMultiDBTestRoot(b, "test-multi-db-set-key-1k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+func BenchmarkMultiDBSetKey2K(b *testing.B) {
+	numDatabases := 2000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetMultiDBTestRoot(b, "test-multi-db-set-key-2k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+func BenchmarkMultiDBSetKey10K(b *testing.B) {
+	numDatabases := 10000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetMultiDBTestRoot(b, "test-multi-db-set-key-10k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+// CAUTION: This benchmark currently breaks due to a bottleneck in cometbft-db
+func BenchmarkMultiDBSetKey100K(b *testing.B) {
+	numDatabases := 100000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetMultiDBTestRoot(b, "test-multi-db-set-key-100k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+// ----------------------------------------------------------------------------
+// Exported helpers
+
+func ResetMultiDBTestRoot(
+	t testing.TB,
+	testName string,
+	numDatabases int,
+) (string, []dbm.DB) {
+	// create a unique, concurrency-safe test directory under os.TempDir()
+	rootDir, err := os.MkdirTemp("", testName)
+	if err != nil {
+		panic(err)
+	}
+
+	// Open numDatabases database adapters
+	dbPtrs, err := createTempMemDB(t, rootDir, numDatabases)
+	require.NoError(t, err, "should create MemDB instances in temp directory")
+
+	return rootDir, dbPtrs
+}
+
+// ----------------------------------------------------------------------------
+
+func createTempMemDB(
+	t testing.TB,
+	rootDir string,
+	numDatabases int,
+) ([]dbm.DB, error) {
+	t.Helper()
+
+	dbPtrs := make([]dbm.DB, numDatabases)
+	dbType := dbm.BackendType("memdb")
+
+	for i := 0; i < numDatabases; i++ {
+		dbDir, err := os.MkdirTemp(rootDir, "cometbft-memdb-*")
+		if err != nil {
+			return dbPtrs, err
+		}
+
+		dbId := "db-" + strconv.Itoa(i)
+		db, err := dbm.NewDB(dbId, dbType, dbDir)
+		require.NoError(t, err, "should create new DB instance")
+
+		dbPtrs[i] = db
+		db.Close() // noop for memdb
+	}
+
+	return dbPtrs, nil
+}

--- a/multiplex/fs.go
+++ b/multiplex/fs.go
@@ -1,0 +1,96 @@
+package multiplex
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+)
+
+// ----------------------------------------------------------------------------
+// Multiplex providers
+
+// MultiplexFSProvider returns multiple data filesystem paths using DefaultDataDir
+// specified in the Config and uses two levels of subfolders for user and scope.
+// The scope-level subfolders are named after the first 8-bytes of the scope hash.
+func MultiplexFSProvider(config *cmtcfg.Config) (multiplex MultiplexFS, err error) {
+
+	// When replication is in singular mode, we will create only one data dir
+	// This mimics the default behaviour of CometBFT blockchain nodes' data dir
+	if config.Replication == cmtcfg.SingularReplicationMode() {
+		multiplex = make(map[string]string, 1)
+		multiplex[""] = cmtcfg.DefaultDataDir
+		return multiplex, nil
+	}
+
+	// This multiplex maps scope hashes to scoped data folders
+	multiplex = map[string]string{}
+
+	// Uses a singleton scope registry to create SHA256 once
+	scopeRegistry, err := DefaultScopeHashProvider(&config.UserConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Storage is located in scopes subfolders per each user
+	baseDataDir := filepath.Join(config.RootDir, cmtcfg.DefaultDataDir)
+	baseConfDir := filepath.Join(config.RootDir, cmtcfg.DefaultConfigDir)
+	for _, userAddress := range config.GetAddresses() {
+		// Uses one subfolder by user in data/ and one in config/
+		userDataDir := filepath.Join(baseDataDir, userAddress)
+		userConfDir := filepath.Join(baseConfDir, userAddress)
+
+		// .. and one subfolder by scope
+		for _, scope := range config.UserScopes[userAddress] {
+			// Query scope hash from registry to avoid re-creating SHA256
+			scopeHash, err := scopeRegistry.GetScopeHash(userAddress, scope)
+			if err != nil {
+				return nil, err
+			}
+
+			// The folder name is the hex representation of the fingerprint
+			scopeId := NewScopeIDFromHash(scopeHash)
+			folderName := scopeId.Fingerprint()
+
+			scopedDataFolder := filepath.Join(userDataDir, folderName)
+			scopedConfFolder := filepath.Join(userConfDir, folderName)
+			multiplex[scopeHash] = scopedDataFolder
+
+			// Any error here means the directory is not accessible
+			if _, err := os.Stat(scopedDataFolder); err != nil {
+				return nil, fmt.Errorf("missing mandatory data folder %s: %w", scopedDataFolder, err)
+			}
+
+			// Any error here means the directory is not accessible
+			if _, err := os.Stat(scopedConfFolder); err != nil {
+				return nil, fmt.Errorf("missing mandatory config folder %s: %w", scopedConfFolder, err)
+			}
+		}
+	}
+
+	return multiplex, nil
+}
+
+// ----------------------------------------------------------------------------
+// Scoped instance getters
+
+// GetScopedFS tries to find a filesystem path in the FS multiplex using its scope hash
+// If an error is produced, the default data dir will be returned alongside the error
+func GetScopedFS(
+	multiplex MultiplexFS,
+	userScopeHash string,
+) (string, error) {
+	scopeHash, err := hex.DecodeString(userScopeHash)
+	if err != nil || len(scopeHash) != sha256.Size {
+		return cmtcfg.DefaultDataDir, fmt.Errorf("incorrect scope hash for state multiplex, got %v bytes, expected %v bytes", len(scopeHash), sha256.Size)
+	}
+
+	if scopedStoragePath, ok := multiplex[userScopeHash]; ok {
+		return scopedStoragePath, nil
+	}
+
+	return cmtcfg.DefaultDataDir, fmt.Errorf("could not find state in multiplex using scope hash %s", scopeHash)
+}

--- a/multiplex/fs_test.go
+++ b/multiplex/fs_test.go
@@ -1,0 +1,199 @@
+package multiplex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/config"
+	mxtest "github.com/cometbft/cometbft/multiplex/test"
+)
+
+func TestMultiplexFSEnsureRootMultiplex(t *testing.T) {
+	require := require.New(t)
+
+	// setup temp dir for test
+	tmpDir, err := os.MkdirTemp("", "config-test")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	// create root dir
+	config.EnsureRoot(tmpDir)
+	config.EnsureRootMultiplex(tmpDir, &config.BaseConfig{
+		UserConfig: config.UserConfig{
+			Replication: config.PluralReplicationMode(),
+			UserScopes: map[string][]string{
+				"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"Default", "Other"},
+				"FF1410CEEB411E55487701C4FEE65AACE7115DC0": {"Default", "ReplChain"},
+			},
+		},
+	})
+
+	// make sure config is set properly
+	data, err := os.ReadFile(filepath.Join(tmpDir, config.DefaultConfigDir, config.DefaultConfigFileName))
+	require.NoError(err)
+
+	assertValidConfig(t, string(data))
+
+	testCases := []string{
+		filepath.Join("data"),
+		filepath.Join("config"),
+		filepath.Join("data", "CC8E6555A3F401FF61DA098F94D325E7041BC43A"),
+		filepath.Join("data", "CC8E6555A3F401FF61DA098F94D325E7041BC43A", "1A63C0E60122F9BB"), // "Default"
+		filepath.Join("data", "CC8E6555A3F401FF61DA098F94D325E7041BC43A", "C26A93BCF48CCE18"), // "Other"
+		filepath.Join("data", "FF1410CEEB411E55487701C4FEE65AACE7115DC0"),
+		filepath.Join("data", "FF1410CEEB411E55487701C4FEE65AACE7115DC0", "D1ED2B487F2E93CC"), // "Default"
+		filepath.Join("data", "FF1410CEEB411E55487701C4FEE65AACE7115DC0", "1A20753306FF8E39"), // "ReplChain"
+		filepath.Join("config", "CC8E6555A3F401FF61DA098F94D325E7041BC43A"),
+		filepath.Join("config", "CC8E6555A3F401FF61DA098F94D325E7041BC43A", "1A63C0E60122F9BB"),
+		filepath.Join("config", "CC8E6555A3F401FF61DA098F94D325E7041BC43A", "C26A93BCF48CCE18"),
+		filepath.Join("config", "FF1410CEEB411E55487701C4FEE65AACE7115DC0"),
+		filepath.Join("config", "FF1410CEEB411E55487701C4FEE65AACE7115DC0", "D1ED2B487F2E93CC"),
+		filepath.Join("config", "FF1410CEEB411E55487701C4FEE65AACE7115DC0", "1A20753306FF8E39"),
+	}
+
+	ensureFiles(t, tmpDir, testCases...)
+}
+
+func TestMultiplexFSProviderCorrectScopeHash(t *testing.T) {
+	require := require.New(t)
+
+	// setup temp dir for test
+	tmpDir, err := os.MkdirTemp("", "config-test")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	expectedNumChains := 2
+	userConfig := config.UserConfig{
+		Replication: config.PluralReplicationMode(),
+		UserScopes: map[string][]string{
+			// mind changing mxtest.TestScopeHash if you make a change here.
+			"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"Default", "Other"},
+		},
+	}
+
+	// create root dir
+	config.EnsureRoot(tmpDir)
+	config.EnsureRootMultiplex(tmpDir, &config.BaseConfig{
+		UserConfig: userConfig,
+	})
+
+	// use provider
+	multiplexFS, err := MultiplexFSProvider(&config.Config{
+		BaseConfig: config.BaseConfig{
+			RootDir:    tmpDir,
+			UserConfig: userConfig,
+		},
+	})
+	require.NoError(err)
+	assert.NotEmpty(t, multiplexFS, "the filesystem multiplex should not be empty")
+	assert.Equal(t, expectedNumChains, len(multiplexFS))
+	assert.Contains(t, multiplexFS, mxtest.TestScopeHash)
+}
+
+func TestMultiplexFSProviderDetectMissingDataFolder(t *testing.T) {
+	require := require.New(t)
+
+	// setup temp dir for test
+	tmpDir, err := os.MkdirTemp("", "config-test")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	// create root dir
+	config.EnsureRoot(tmpDir)
+	config.EnsureRootMultiplex(tmpDir, &config.BaseConfig{
+		UserConfig: config.UserConfig{
+			Replication: config.PluralReplicationMode(),
+			UserScopes: map[string][]string{
+				"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"Default", "Other"},
+			},
+		},
+	})
+
+	// use provider
+	multiplexFS, err := MultiplexFSProvider(&config.Config{
+		BaseConfig: config.BaseConfig{
+			RootDir: tmpDir,
+			UserConfig: config.UserConfig{
+				Replication: config.PluralReplicationMode(),
+				UserScopes: map[string][]string{
+					"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"DOES_NOT_EXIST"},
+				},
+			},
+		},
+	})
+	assert.Nil(t, multiplexFS)
+	assert.Error(t, err, "mandatory filesystem path cannot be missing")
+}
+
+func TestMultiplexFSProviderComplexReplicatedChains(t *testing.T) {
+	require := require.New(t)
+
+	// setup temp dir for test
+	tmpDir, err := os.MkdirTemp("", "config-test")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	expectedNumChains := 12
+	complexUserConfig := config.UserConfig{
+		Replication: config.PluralReplicationMode(),
+		UserScopes: map[string][]string{
+			"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"Default", "Other"},
+			"FF1410CEEB411E55487701C4FEE65AACE7115DC0": {"Default", "ReplChain", "Third", "Fourth", "Fifth"},
+			"BB2B85FABDAF8469F5A0F10AB3C060DE77D409BB": {"Cosmos", "ReplChain", "Default"},
+			"5168FD905426DE2E0DB9990B35075EEC3B184977": {"First", "Second"},
+		},
+	}
+
+	// create root dir
+	config.EnsureRoot(tmpDir)
+	config.EnsureRootMultiplex(tmpDir, &config.BaseConfig{
+		UserConfig: complexUserConfig,
+	})
+
+	// use provider
+	multiplexFS, err := MultiplexFSProvider(&config.Config{
+		BaseConfig: config.BaseConfig{
+			RootDir:    tmpDir,
+			UserConfig: complexUserConfig,
+		},
+	})
+	require.NoError(err)
+	assert.NotEmpty(t, multiplexFS, "the filesystem multiplex should not be empty")
+	assert.Equal(t, expectedNumChains, len(multiplexFS))
+}
+
+func ensureFiles(t *testing.T, rootDir string, files ...string) {
+	t.Helper()
+	for _, f := range files {
+		p := filepath.Join(rootDir, f)
+		_, err := os.Stat(p)
+		require.NoError(t, err, p)
+	}
+}
+
+func assertValidConfig(t *testing.T, configFile string) {
+	t.Helper()
+	// list of words we expect in the config
+	elems := []string{
+		"moniker",
+		"seeds",
+		"proxy_app",
+		"create_empty_blocks",
+		"peer",
+		"timeout",
+		"broadcast",
+		"send",
+		"addr",
+		"wal",
+		"propose",
+		"max",
+		"genesis",
+	}
+	for _, e := range elems {
+		assert.Contains(t, configFile, e)
+	}
+}

--- a/multiplex/genesis_set.go
+++ b/multiplex/genesis_set.go
@@ -1,0 +1,202 @@
+package multiplex
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/merkle"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	cmtos "github.com/cometbft/cometbft/internal/os"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	types "github.com/cometbft/cometbft/types"
+)
+
+//------------------------------------------------------------
+// core types for a blockchain genesis in plural replication mode
+// - struct ChecksummedGenesisDocSet implements IChecksummedGenesisDoc
+// - struct UserScopedGenesisDoc embeds GenesisDoc
+// - struct GenesisDocSet contains a slice of UserScopedGenesisDoc
+
+// ChecksummedUserScopedGenesisDoc combines a GenesisDoc together with its
+// SHA256 checksum and the user address.
+type ChecksummedGenesisDocSet struct {
+	GenesisDocs    GenesisDocSet
+	Sha256Checksum []byte
+}
+
+// DefaultGenesisDoc() implements IChecksummedGenesisDoc
+func (c *ChecksummedGenesisDocSet) DefaultGenesisDoc() (*types.GenesisDoc, error) {
+	if len(c.GenesisDocs.GenesisDocs) > 1 {
+		return nil, fmt.Errorf("no default genesis doc available in plural replication mode")
+	}
+
+	return &c.GenesisDocs.GenesisDocs[0].GenesisDoc, nil
+}
+
+// GenesisDocByScope() implements IChecksummedGenesisDoc
+// This method returns an error when the genesis doc cannot be
+// found for the userScopeHash SHA256 hash.
+func (c *ChecksummedGenesisDocSet) GenesisDocByScope(
+	userScopeHash string,
+) (*types.GenesisDoc, error) {
+	if doc, ok, _ := c.GenesisDocs.SearchGenesisDocByScope(userScopeHash); ok {
+		return &doc.GenesisDoc, nil
+	}
+
+	return nil, fmt.Errorf("could not find genesis doc for user %s", userScopeHash)
+}
+
+// GetChecksum() implements IChecksummedGenesisDoc
+func (c *ChecksummedGenesisDocSet) GetChecksum() []byte {
+	return c.Sha256Checksum
+}
+
+// UserScopedGenesisDoc defines a mapping with a composite key made of a user
+// address and an arbitrary string-typed scope, to the initial conditions
+// for CometBFT blockchains.
+//
+// XXX:
+// TBI whether UserAddress and Scope are necessary in genesis doc due to the
+// Config structs already including these, they may be skipped here if they
+// can be filled through configuration files otherwise.
+type UserScopedGenesisDoc struct {
+	UserAddress crypto.Address   `json:"user_address"`
+	Scope       string           `json:"scope"`
+	GenesisDoc  types.GenesisDoc `json:"genesis"`
+	ScopeHash   string
+}
+
+// GenesisDocSet defines the initial conditions for multiple CometBFT blockchains,
+// in particular their validator set and the mapping between a UserAddress and ChainID.
+// XXX would a multiplex object be more comfortable? take into account JSON format
+type GenesisDocSet struct {
+	GenesisDocs []UserScopedGenesisDoc
+}
+
+// SaveAs is a utility method for saving GenesisDocSet as a JSON file
+func (genDocSet *GenesisDocSet) SaveAs(file string) error {
+	genDocSetBytes, err := cmtjson.Marshal(genDocSet.GenesisDocs)
+	if err != nil {
+		return err
+	}
+	//fmt.Printf("docSetBytes: %s", genDocSetBytes)
+	return cmtos.WriteFile(file, genDocSetBytes, 0644)
+}
+
+// ValidatorHash returns the Merkle root hash built using genesis doc's
+// validator hashes (as leaves).
+func (genDocSet *GenesisDocSet) ValidatorHash() []byte {
+	bzs := make([][]byte, len(genDocSet.GenesisDocs))
+	for _, genDoc := range genDocSet.GenesisDocs {
+		bzs = append(bzs, genDoc.GenesisDoc.ValidatorHash())
+	}
+	return merkle.HashFromByteSlices(bzs)
+}
+
+// ValidateAndComplete checks that all necessary fields are present,
+// then fills in defaults for optional fields left empty for each of
+// the set's genesis docs and computes composite scope SHA256 hashes.
+func (genDocSet *GenesisDocSet) ValidateAndComplete() error {
+	if len(genDocSet.GenesisDocs) < 1 {
+		return fmt.Errorf("encountered empty GenesisDocSet")
+	}
+
+	users := map[string]bool{}
+	chains := map[string]bool{}
+	for i, userGenDoc := range genDocSet.GenesisDocs {
+		userChainID := userGenDoc.GenesisDoc.ChainID
+
+		// Validate the address
+		address := userGenDoc.UserAddress
+		if len(address) != tmhash.TruncatedSize {
+			return fmt.Errorf("incorrect address for user in the genesis file, got %d bytes, expected %d bytes", len(address), tmhash.TruncatedSize)
+		}
+
+		// Scope may not be empty
+		if len(userGenDoc.Scope) == 0 {
+			return fmt.Errorf("user scopes may not be empty in the genesis file")
+		}
+
+		// Generate the ScopeHash
+		sid := NewScopeID(userGenDoc.UserAddress.String(), userGenDoc.Scope)
+		userGenDoc.ScopeHash = sid.Hash()
+
+		if _, ok := users[userGenDoc.ScopeHash]; ok {
+			return fmt.Errorf("duplicate scope hash in the genesis file for pair of user %v and scope %s", address, userGenDoc.Scope)
+		}
+
+		if _, ok := chains[userChainID]; ok {
+			return fmt.Errorf("ChainID already exists in the genesis file for pair of user %v and scope %s", address, userGenDoc.Scope)
+		}
+
+		err := userGenDoc.GenesisDoc.ValidateAndComplete()
+
+		if err != nil {
+			return err
+		}
+
+		// Flag for uniqueness
+		users[userGenDoc.ScopeHash] = true
+		chains[userChainID] = true
+		genDocSet.GenesisDocs[i] = userGenDoc
+	}
+
+	return nil
+}
+
+// SearchGenesisDocByScope starts a search for a UserScopedGenesisDoc mapped to
+// the given user address. A hash of length tmhash.TruncatedSize is used.
+func (genDocSet *GenesisDocSet) SearchGenesisDocByScope(
+	userScopeHash string,
+) (doc UserScopedGenesisDoc, found bool, err error) {
+	scopeHash, err := hex.DecodeString(userScopeHash)
+	if err != nil || len(scopeHash) != sha256.Size {
+		return UserScopedGenesisDoc{}, false, fmt.Errorf("incorrect scope hash for genesis doc search, got %v bytes, expected %v bytes", len(scopeHash), sha256.Size)
+	}
+
+	if idx := slices.IndexFunc(genDocSet.GenesisDocs, func(d UserScopedGenesisDoc) bool {
+		return d.ScopeHash == userScopeHash
+	}); idx > -1 {
+		return genDocSet.GenesisDocs[idx], true, nil
+	}
+
+	return UserScopedGenesisDoc{}, false, nil
+}
+
+//------------------------------------------------------------
+// Make genesis set state from file
+
+// GenesisDocSetFromJSON unmarshalls JSON data into a GenesisDocSet.
+func GenesisDocSetFromJSON(jsonBlob []byte) (*GenesisDocSet, error) {
+	genDocSet := &GenesisDocSet{
+		GenesisDocs: make([]UserScopedGenesisDoc, 0),
+	}
+
+	err := cmtjson.Unmarshal(jsonBlob, &genDocSet.GenesisDocs)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := genDocSet.ValidateAndComplete(); err != nil {
+		return nil, err
+	}
+
+	return genDocSet, err
+}
+
+// GenesisDocSetFromFile reads JSON data from a file and unmarshalls it into a GenesisDocSet.
+func GenesisDocSetFromFile(genDocSetFile string) (*GenesisDocSet, error) {
+	jsonBlob, err := os.ReadFile(genDocSetFile)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read GenesisDocSet file: %w", err)
+	}
+	genDocSet, err := GenesisDocSetFromJSON(jsonBlob)
+	if err != nil {
+		return nil, fmt.Errorf("error reading GenesisDocSet at %s: %w", genDocSetFile, err)
+	}
+	return genDocSet, nil
+}

--- a/multiplex/genesis_set_test.go
+++ b/multiplex/genesis_set_test.go
@@ -1,0 +1,334 @@
+package multiplex
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	types "github.com/cometbft/cometbft/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+)
+
+func TestMultiplexGenesisDocSetBad(t *testing.T) {
+	// test some bad ones from raw json
+	testCases := [][]byte{
+		{},               // empty
+		{1},              // junk
+		[]byte(`{null}`), // invalid GenesisDocs
+		[]byte(`[]`),     // empty GenesisDocs
+		[]byte(`[{}]`),   // invalid GenesisDocs
+		[]byte(`[{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF"}]`),                     // missing scope and GenesisDoc fields
+		[]byte(`[{"scope": "Default"}]`),                                                             // missing user address and GenesisDoc fields
+		[]byte(`[{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF", "scope": "Default"}]`), // missing GenesisDoc fields
+		[]byte(`[{"user_address": null, "scope": "Default", "genesis": {"chain_id": "abc", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}}]`),                                  // nil user address
+		[]byte(`[{"user_address": "A0", "scope": "Default", "genesis": {"chain_id": "abc", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}}]`),                                  // junk user address
+		[]byte(`[{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF", "scope": null, "genesis": {"chain_id": "abc", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}}]`), // nil scope
+		[]byte(`[
+			{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF", "scope": "Default", "genesis": {"chain_id": "abc1", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}},
+			{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF", "scope": "Default", "genesis": {"chain_id": "abc2", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}}
+		]`), // scope hash not unique
+		[]byte(`[
+			{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF", "scope": "Default" "genesis": {"chain_id": "abc1", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}},
+			{"user_address": "FF080888BE0F48DE88927C3F49215B96548273AB", "scope": "Other", "genesis": {"chain_id": "abc2", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Charlie"}}},
+			{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF", "scope": "Default", "genesis": {"chain_id": "abc3", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Dave"}}}
+		]`), // scope hash not unique
+		[]byte(`[
+			{"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF", "scope": "Default", "genesis": {"chain_id": "same-chain", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}},
+			{"user_address": "FF080888BE0F48DE88927C3F49215B96548273AB", "scope": "Default", "genesis": {"chain_id": "same-chain", "initial_height": "1", "consensus_params": null, "validators": null,"app_hash":"","app_state":{"account_owner":"Bob"}}}
+		]`), // ChainID not unique
+	}
+
+	for i, testCase := range testCases {
+		_, err := GenesisDocSetFromJSON(testCase)
+
+		assert.Error(t, err, "expected error for invalid genDocSet json at "+strconv.Itoa(i))
+	}
+}
+
+func TestMultiplexGenesisDocSetGood(t *testing.T) {
+	// test one genesis doc by raw json
+	genDocSetBytes := []byte(`[
+		{
+			"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF",
+			"scope": "Default",
+			"genesis": {
+				"genesis_time": "0001-01-01T00:00:00Z",
+				"chain_id": "test-chain-QDKdJr",
+				"initial_height": "1000",
+				"consensus_params": null,
+				"validators": [{
+					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
+					"power":"10",
+					"name":""
+				}],
+				"app_hash":"",
+				"app_state":{"account_owner":"Bob"}
+			}
+		}
+	]`)
+	_, err := GenesisDocSetFromJSON(genDocSetBytes)
+	assert.NoError(t, err, "expected no error for correct genesis docs set with single user from json")
+
+	// test multiple genesis docs by a correct raw json
+	genDocSetBytesMultiple := []byte(`[
+		{
+			"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF",
+			"scope": "Default",
+			"genesis": {
+				"genesis_time": "0001-01-01T00:00:00Z",
+				"chain_id": "test-chain-QDKdJr-1",
+				"initial_height": "1000",
+				"consensus_params": null,
+				"validators": [{
+					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"8y+xNWFp1i6PZeu5o9wfmDL6nwfMDxF6tVVJwTOmVjo="},
+					"power":"10",
+					"name":""
+				}],
+				"app_hash":"",
+				"app_state":{"account_owner":"Bob"}
+			}
+		},
+		{
+			"user_address": "CC8E6555A3F401FF61DA098F94D325E7041BC43A",
+			"scope": "Default",
+			"genesis": {
+				"genesis_time": "0001-01-01T00:00:00Z",
+				"chain_id": "test-chain-QDKdJr-2",
+				"initial_height": "1000",
+				"consensus_params": null,
+				"validators": [{
+					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
+					"power":"10",
+					"name":""
+				}],
+				"app_hash":"",
+				"app_state":{"account_owner":"Bob"}
+			}
+		}
+	]`)
+	_, err = GenesisDocSetFromJSON(genDocSetBytesMultiple)
+	assert.NoError(t, err, "expected no error for correct genesis docs set with multiple users from json")
+
+	// test multiple genesis docs by a correct raw json
+	genDocSetBytesMultipleScopes := []byte(`[
+		{
+			"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF",
+			"scope": "Default",
+			"genesis": {
+				"genesis_time": "0001-01-01T00:00:00Z",
+				"chain_id": "test-chain-QDKdJr-1",
+				"initial_height": "1000",
+				"consensus_params": null,
+				"validators": [{
+					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"8y+xNWFp1i6PZeu5o9wfmDL6nwfMDxF6tVVJwTOmVjo="},
+					"power":"10",
+					"name":""
+				}],
+				"app_hash":"",
+				"app_state":{"account_owner":"Bob"}
+			}
+		},
+		{
+			"user_address": "FF190888BE0F48DE88927C3F49215B96548273AF",
+			"scope": "Another",
+			"genesis": {
+				"genesis_time": "0001-01-01T00:00:00Z",
+				"chain_id": "test-chain-QDKdJr-2",
+				"initial_height": "1000",
+				"consensus_params": null,
+				"validators": [{
+					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"8y+xNWFp1i6PZeu5o9wfmDL6nwfMDxF6tVVJwTOmVjo="},
+					"power":"10",
+					"name":""
+				}],
+				"app_hash":"",
+				"app_state":{"account_owner":"Bob"}
+			}
+		}
+	]`)
+	_, err = GenesisDocSetFromJSON(genDocSetBytesMultipleScopes)
+	assert.NoError(t, err, "expected no error for correct genesis docs set with multiple scopes from json")
+
+	// create a GenesisDocSet from struct
+	userPubKey := ed25519.GenPrivKey().PubKey()
+	valPubKey := ed25519.GenPrivKey().PubKey()
+	baseGenDocSet := &GenesisDocSet{
+		GenesisDocs: []UserScopedGenesisDoc{
+			{
+				UserAddress: userPubKey.Address(),
+				GenesisDoc: types.GenesisDoc{
+					ChainID: "abc",
+					Validators: []types.GenesisValidator{{
+						Address: valPubKey.Address(),
+						PubKey:  valPubKey,
+						Power:   10,
+						Name:    "myval",
+					}},
+				},
+			},
+		},
+	}
+	_, err = cmtjson.Marshal(baseGenDocSet)
+	assert.NoError(t, err, "error marshaling genDocSet")
+
+	// create multiple UserScopedGenesisDoc from struct
+	genDocSetDefault := randomGenesisDocSet(3)
+	err = genDocSetDefault.ValidateAndComplete()
+	assert.NoError(t, err, "expected no error from random correct genDocSet struct")
+}
+
+func TestMultiplexGenesisDocSetSaveAs(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "genesis")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	genDocSet := randomGenesisDocSet()
+
+	// save
+	err = genDocSet.SaveAs(tmpfile.Name())
+	require.NoError(t, err)
+	stat, err := tmpfile.Stat()
+	require.NoError(t, err)
+	if err != nil && stat.Size() <= 0 {
+		t.Fatalf("SaveAs failed to write any bytes to %v", tmpfile.Name())
+	}
+
+	err = tmpfile.Close()
+	require.NoError(t, err)
+
+	// load
+	genDocSet2, err := GenesisDocSetFromFile(tmpfile.Name())
+	require.NoError(t, err)
+	assert.EqualValues(t, genDocSet2, genDocSet)
+	assert.Equal(t, genDocSet2.GenesisDocs, genDocSet.GenesisDocs)
+}
+
+func TestMultiplexGenesisDocSetValidatorHash(t *testing.T) {
+	genDocSet := randomGenesisDocSet()
+	assert.NotEmpty(t, genDocSet.ValidatorHash())
+}
+
+func TestMultiplexGenesisDocSetSearchGenesisDocByUser(t *testing.T) {
+	// defines a correct genesis doc
+	genDocSetFmt := `[
+		{
+			"user_address": "%s",
+			"scope": "%s",
+			"genesis": {
+				"genesis_time": "0001-01-01T00:00:00Z",
+				"chain_id": "test-chain-1",
+				"initial_height": "1000",
+				"consensus_params": null,
+				"validators": [{
+					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"8y+xNWFp1i6PZeu5o9wfmDL6nwfMDxF6tVVJwTOmVjo="},
+					"power":"10",
+					"name":""
+				}],
+				"app_hash":"",
+				"app_state":{"account_owner":"Bob"}
+			}
+		}
+	]`
+
+	// searching for an existing scope
+	testCases := [][]string{
+		{"FF190888BE0F48DE88927C3F49215B96548273AF", "Default"},
+		{"CC8E6555A3F401FF61DA098F94D325E7041BC43A", "Default"},
+	}
+
+	for i, testCaseData := range testCases {
+		testCaseUserAddress, testCaseScope := testCaseData[0], testCaseData[1]
+		testCaseGenesis := fmt.Sprintf(genDocSetFmt, testCaseUserAddress, testCaseScope)
+		testCaseDocSet, err := GenesisDocSetFromJSON([]byte(testCaseGenesis))
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(testCaseDocSet.GenesisDocs))
+
+		testCaseScopeID := NewScopeID(testCaseUserAddress, testCaseScope)
+		testCaseScopeHash := testCaseScopeID.Hash()
+		assert.NotEmpty(t, testCaseScopeHash, "scopeID hash should not be empty")
+
+		doc, ok, err := testCaseDocSet.SearchGenesisDocByScope(testCaseScopeHash)
+		assert.NoError(t, err)
+		assert.Equal(t, true, ok, "scope hash should be found at "+strconv.Itoa(i))
+		assert.Equal(t, testCaseUserAddress, doc.UserAddress.String())
+	}
+
+	// searching for non-existing scopes
+	testCases = [][]string{
+		{"AA190888BE0F48DE88927C3F49215B96548273AF", "Default"}, // 1-byte address change
+		{"FF190888BE0F48DE88927C3F49215B96548273AF", "default"}, // 1-byte scope change
+	}
+
+	failCaseGenesis := fmt.Sprintf(genDocSetFmt, "FF190888BE0F48DE88927C3F49215B96548273AF", "Default")
+	failCaseDocSet, err := GenesisDocSetFromJSON([]byte(failCaseGenesis))
+	require.NoError(t, err)
+
+	for _, failCaseData := range testCases {
+		failCaseUserAddress, failCaseScope := failCaseData[0], failCaseData[1]
+
+		failCaseScopeID := NewScopeID(failCaseUserAddress, failCaseScope)
+		failCaseScopeHash := failCaseScopeID.Hash()
+		assert.NotEmpty(t, failCaseScopeHash, "scopeID hash should not be empty")
+
+		doc, ok, err := failCaseDocSet.SearchGenesisDocByScope(failCaseScopeHash)
+		assert.NoError(t, err)
+		assert.Equal(t, false, ok)
+		assert.Empty(t, doc)
+	}
+
+	// searching for invalid scope hashes (sha256)
+	testCases = [][]string{
+		{""},   // empty
+		{"A0"}, // too short
+		{"AA190888BE0F48DE88927C3F49215B96548273AFAA190888BE0F48DE88927C3F49215B96548273AF"}, // too long
+	}
+
+	for _, failCaseScopeHash := range testCases {
+		_, ok, err := failCaseDocSet.SearchGenesisDocByScope(failCaseScopeHash[0])
+		assert.Error(t, err)
+		assert.Equal(t, false, ok)
+	}
+}
+
+func randomGenesisDocSet(opt ...int) *GenesisDocSet {
+	cnt := 2
+	if len(opt) > 0 {
+		cnt = opt[0]
+	}
+
+	var userGenDocs []UserScopedGenesisDoc
+	for i := 0; i < cnt; i++ {
+		userPubKey := ed25519.GenPrivKey().PubKey()
+		valPubKey := ed25519.GenPrivKey().PubKey()
+		scopeId := NewScopeID(userPubKey.Address().String(), "Default")
+
+		userGenDocs = append(userGenDocs, UserScopedGenesisDoc{
+			UserAddress: userPubKey.Address(),
+			Scope:       "Default",
+			ScopeHash:   scopeId.Hash(),
+			GenesisDoc: types.GenesisDoc{
+				GenesisTime:   cmttime.Now(),
+				ChainID:       "test-chain-" + strconv.Itoa(i),
+				InitialHeight: 1000,
+				Validators: []types.GenesisValidator{{
+					Address: valPubKey.Address(),
+					PubKey:  valPubKey,
+					Power:   10,
+					Name:    "myval",
+				}},
+				ConsensusParams: types.DefaultConsensusParams(),
+				AppHash:         []byte{1, 2, 3},
+				AppState:        []byte(`{"account_owner":"Bob"}`),
+			},
+		})
+	}
+	return &GenesisDocSet{
+		GenesisDocs: userGenDocs,
+	}
+}

--- a/multiplex/multiplex.go
+++ b/multiplex/multiplex.go
@@ -1,0 +1,11 @@
+package multiplex
+
+// ----------------------------------------------------------------------------
+// FILESYSTEM
+
+// MultiplexGroup maps scope hashes to autofile group instances
+type MultiplexGroup map[string]*ScopedGroup
+
+// MultiplexWAL maps scope hashes to scoped WAL instances
+type MultiplexWAL map[string]*ScopedWAL
+

--- a/multiplex/p2p_test.go
+++ b/multiplex/p2p_test.go
@@ -1,0 +1,183 @@
+package multiplex
+
+import (
+	//"fmt"
+	"os"
+	"testing"
+
+	dbm "github.com/cometbft/cometbft-db"
+	"github.com/cosmos/gogoproto/proto"
+
+	p2pproto "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
+	"github.com/cometbft/cometbft/config"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
+	"github.com/cometbft/cometbft/libs/log"
+	cmtsync "github.com/cometbft/cometbft/libs/sync"
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/p2p/conn"
+)
+
+func benchmarkSwitchBroadcast(b *testing.B, dbs []dbm.DB, switches []*p2p.Switch, numPairs int) {
+	b.Helper()
+
+	// Creates a thread-safe rand instance
+	randomizer := cmtrand.NewRand()
+	chMsg := &p2pproto.PexAddrs{
+		Addrs: []p2pproto.NetAddress{
+			{
+				ID: "1",
+			},
+		},
+	}
+
+	b.SetParallelism(numPairs * 2) // 1 proc per switch
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Every iteration should transport a message from switch 1 to switch 2
+		for pb.Next() {
+			switchIdx := randomizer.Intn(numPairs * 2)
+			sw := switches[switchIdx]
+
+			// Transport a message
+			chID := byte(switchIdx % 4)
+			sw.Broadcast(p2p.Envelope{ChannelID: chID, Message: chMsg})
+		}
+	})
+}
+
+// ----------------------------------------------------------------------------
+// cometbft Switch implementation benchmarks
+
+func BenchmarkP2PTransport1K(b *testing.B) {
+	numPairs := 1000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs, switchPtrs := ResetP2PTestRoot(b, "test-p2p-transport-1k", numPairs)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numPairs*2
+	benchmarkSwitchBroadcast(b, dbPtrs, switchPtrs, numPairs)
+}
+
+// ----------------------------------------------------------------------------
+// Mocks and Test Helpers
+
+var cfg *config.P2PConfig
+
+func init() {
+	cfg = config.DefaultP2PConfig()
+	cfg.PexReactor = true
+	cfg.AllowDuplicateIP = true
+}
+
+type PeerMessage struct {
+	Contents proto.Message
+	Counter  int
+}
+
+type TestReactor struct {
+	p2p.BaseReactor
+
+	mtx          cmtsync.Mutex
+	channels     []*conn.ChannelDescriptor
+	logMessages  bool
+	msgsCounter  int
+	msgsReceived map[byte][]PeerMessage
+}
+
+func NewTestReactor(channels []*conn.ChannelDescriptor, logMessages bool) *TestReactor {
+	tr := &TestReactor{
+		channels:     channels,
+		logMessages:  logMessages,
+		msgsReceived: make(map[byte][]PeerMessage),
+	}
+	tr.BaseReactor = *p2p.NewBaseReactor("TestReactor", tr)
+	tr.SetLogger(log.TestingLogger())
+	return tr
+}
+
+func (tr *TestReactor) GetChannels() []*conn.ChannelDescriptor {
+	return tr.channels
+}
+
+func (*TestReactor) AddPeer(p2p.Peer) {}
+
+func (*TestReactor) RemovePeer(p2p.Peer, any) {}
+
+func (tr *TestReactor) Receive(e p2p.Envelope) {
+	if tr.logMessages {
+		tr.mtx.Lock()
+		defer tr.mtx.Unlock()
+		//fmt.Printf("Received: %X, %X\n", e.ChannelID, e.Message)
+		tr.msgsReceived[e.ChannelID] = append(tr.msgsReceived[e.ChannelID], PeerMessage{Contents: e.Message, Counter: tr.msgsCounter})
+		tr.msgsCounter++
+	}
+}
+
+func (tr *TestReactor) getMsgs(chID byte) []PeerMessage {
+	tr.mtx.Lock()
+	defer tr.mtx.Unlock()
+	return tr.msgsReceived[chID]
+}
+
+// ----------------------------------------------------------------------------
+// Exported helpers
+
+func ResetP2PTestRoot(t testing.TB, testName string, numPairs int) (string, []dbm.DB, []*p2p.Switch) {
+	t.Helper()
+
+	// Creates many *prefixed* database instances using global db
+	rootDir, dbPtrs := ResetPrefixDBTestRoot(t, "p2p_", numPairs)
+
+	// Prepares slice of P2P switches
+	switchPtrs := make([]*p2p.Switch, numPairs*2)
+
+	// Creates many connected pairs of *P2P* switches
+	for i := 0; i < numPairs; i++ {
+		sw1, sw2 := MakeSwitchPair(initSwitchFn)
+
+		t.Cleanup(func() {
+			if err := sw2.Stop(); err != nil {
+				t.Error(err)
+			}
+			if err := sw1.Stop(); err != nil {
+				t.Error(err)
+			}
+		})
+
+		idx := i * 2
+		switchPtrs[idx] = sw1
+		switchPtrs[idx+1] = sw2
+	}
+
+	return rootDir, dbPtrs, switchPtrs
+}
+
+// convenience method for creating two switches connected to each other.
+// XXX: note this uses net.Pipe and not a proper TCP conn.
+func MakeSwitchPair(initSwitch func(int, *p2p.Switch) *p2p.Switch) (*p2p.Switch, *p2p.Switch) {
+	// Create two switches that will be interconnected.
+	switches := p2p.MakeConnectedSwitches(cfg, 2, initSwitch, p2p.Connect2Switches)
+	return switches[0], switches[1]
+}
+
+// ----------------------------------------------------------------------------
+
+func initSwitchFn(_ int, sw *p2p.Switch) *p2p.Switch {
+	sw.SetAddrBook(&p2p.AddrBookMock{
+		Addrs:    make(map[string]struct{}),
+		OurAddrs: make(map[string]struct{}),
+	})
+
+	// Make two reactors of two channels each
+	sw.AddReactor("foo", NewTestReactor([]*conn.ChannelDescriptor{
+		{ID: byte(0x00), Priority: 10, MessageType: &p2pproto.Message{}},
+		{ID: byte(0x01), Priority: 10, MessageType: &p2pproto.Message{}},
+	}, true))
+	sw.AddReactor("bar", NewTestReactor([]*conn.ChannelDescriptor{
+		{ID: byte(0x02), Priority: 10, MessageType: &p2pproto.Message{}},
+		{ID: byte(0x03), Priority: 10, MessageType: &p2pproto.Message{}},
+	}, true))
+
+	return sw
+}

--- a/multiplex/p2p_test.go
+++ b/multiplex/p2p_test.go
@@ -1,23 +1,26 @@
 package multiplex
 
 import (
-	//"fmt"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/gogoproto/proto"
 
 	p2pproto "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
 	"github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	cmtnet "github.com/cometbft/cometbft/internal/net"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/libs/log"
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/p2p/conn"
+	"github.com/cometbft/cometbft/version"
 )
 
-func benchmarkSwitchBroadcast(b *testing.B, dbs []dbm.DB, switches []*p2p.Switch, numPairs int) {
+func benchmarkSwitchBroadcast(b *testing.B, switches []*p2p.Switch, numPairs int) {
 	b.Helper()
 
 	// Creates a thread-safe rand instance
@@ -45,18 +48,55 @@ func benchmarkSwitchBroadcast(b *testing.B, dbs []dbm.DB, switches []*p2p.Switch
 	})
 }
 
+func benchmarkTransportValidate(b *testing.B, transports []*p2p.MultiplexTransport, keys []p2p.NodeKey, numNodes int) {
+	b.Helper()
+
+	// Creates a thread-safe rand instance
+	randomizer := cmtrand.NewRand()
+
+	b.SetParallelism(numNodes) // 1 proc per transport
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Every iteration should test the dialer of a multiplex transport instance
+		// and accept an incoming connection.
+		for pb.Next() {
+			mtIdx := randomizer.Intn(numNodes)
+			mt := transports[mtIdx]
+			nk := keys[mtIdx]
+			id := nk.ID()
+
+			laddr := p2p.NewNetAddress(id, mt.GetListener().Addr())
+			mt.Dial(*laddr, p2p.PublicPeerConfig{}.GetConfig())
+		}
+	})
+}
+
 // ----------------------------------------------------------------------------
 // cometbft Switch implementation benchmarks
 
-func BenchmarkP2PTransport1K(b *testing.B) {
+func BenchmarkP2PSwitch1K(b *testing.B) {
 	numPairs := 1000
 
 	// Reset benchmark fs
-	rootDir, dbPtrs, switchPtrs := ResetP2PTestRoot(b, "test-p2p-transport-1k", numPairs)
+	rootDir, switchPtrs := ResetP2PSwitchTestRoot(b, "test-p2p-transport-1k", numPairs)
 	defer os.RemoveAll(rootDir)
 
 	// Runs b.RunParallel() with GOMAXPROCS=numPairs*2
-	benchmarkSwitchBroadcast(b, dbPtrs, switchPtrs, numPairs)
+	benchmarkSwitchBroadcast(b, switchPtrs, numPairs)
+}
+
+// ----------------------------------------------------------------------------
+// cometbft MultiplexTransport implementation benchmarks
+
+func BenchmarkP2PTransport1K(b *testing.B) {
+	numNodes := 1000
+
+	// Reset benchmark fs
+	rootDir, mtPtrs, keyPtrs := ResetP2PTransportTestRoot(b, "test-p2p-transport-1k", numNodes)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numNodes
+	benchmarkTransportValidate(b, mtPtrs, keyPtrs, numNodes)
 }
 
 // ----------------------------------------------------------------------------
@@ -85,6 +125,8 @@ type TestReactor struct {
 	msgsReceived map[byte][]PeerMessage
 }
 
+var _ p2p.Reactor = (*TestReactor)(nil)
+
 func NewTestReactor(channels []*conn.ChannelDescriptor, logMessages bool) *TestReactor {
 	tr := &TestReactor{
 		channels:     channels,
@@ -96,14 +138,18 @@ func NewTestReactor(channels []*conn.ChannelDescriptor, logMessages bool) *TestR
 	return tr
 }
 
+// GetChannels implements Reactor
 func (tr *TestReactor) GetChannels() []*conn.ChannelDescriptor {
 	return tr.channels
 }
 
+// AddPeer implements Reactor
 func (*TestReactor) AddPeer(p2p.Peer) {}
 
+// RemovePeer implements Reactor
 func (*TestReactor) RemovePeer(p2p.Peer, any) {}
 
+// Receive implements Reactor
 func (tr *TestReactor) Receive(e p2p.Envelope) {
 	if tr.logMessages {
 		tr.mtx.Lock()
@@ -114,20 +160,14 @@ func (tr *TestReactor) Receive(e p2p.Envelope) {
 	}
 }
 
-func (tr *TestReactor) getMsgs(chID byte) []PeerMessage {
-	tr.mtx.Lock()
-	defer tr.mtx.Unlock()
-	return tr.msgsReceived[chID]
-}
-
 // ----------------------------------------------------------------------------
 // Exported helpers
 
-func ResetP2PTestRoot(t testing.TB, testName string, numPairs int) (string, []dbm.DB, []*p2p.Switch) {
+func ResetP2PSwitchTestRoot(t testing.TB, testName string, numPairs int) (string, []*p2p.Switch) {
 	t.Helper()
 
 	// Creates many *prefixed* database instances using global db
-	rootDir, dbPtrs := ResetPrefixDBTestRoot(t, "p2p_", numPairs)
+	rootDir, _ := ResetPrefixDBTestRoot(t, testName, numPairs)
 
 	// Prepares slice of P2P switches
 	switchPtrs := make([]*p2p.Switch, numPairs*2)
@@ -150,10 +190,57 @@ func ResetP2PTestRoot(t testing.TB, testName string, numPairs int) (string, []db
 		switchPtrs[idx+1] = sw2
 	}
 
-	return rootDir, dbPtrs, switchPtrs
+	return rootDir, switchPtrs
 }
 
-// convenience method for creating two switches connected to each other.
+func ResetP2PTransportTestRoot(t testing.TB, testName string, numNodes int) (string, []*p2p.MultiplexTransport, []p2p.NodeKey) {
+	t.Helper()
+
+	// Creates many *prefixed* database instances using global db
+	rootDir, _ := ResetPrefixDBTestRoot(t, testName, numNodes)
+
+	// Prepares slice of P2P transport multiplexes
+	mtPtrs := make([]*p2p.MultiplexTransport, numNodes)
+	keyPtrs := make([]p2p.NodeKey, numNodes)
+
+	// Creates many multiplex transport instances
+	for i := 0; i < numNodes; i++ {
+		pv := ed25519.GenPrivKey()
+		id := p2p.PubKeyToID(pv.PubKey())
+		nk := p2p.NodeKey{
+			PrivKey: pv,
+		}
+
+		mt := newMultiplexTransport(
+			testNodeInfo(
+				id, "transport",
+			),
+			nk,
+		)
+
+		// Unlimited incoming connections
+		p2p.MultiplexTransportMaxIncomingConnections(0)(mt)
+
+		addr, err := p2p.NewNetAddressString(p2p.IDAddressString(id, "127.0.0.1:0"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := mt.Listen(*addr); err != nil {
+			t.Fatal(err)
+		}
+
+		// give the listener some time to get ready
+		time.Sleep(20 * time.Millisecond)
+
+		mtPtrs[i] = mt
+		keyPtrs[i] = nk
+	}
+
+	return rootDir, mtPtrs, keyPtrs
+}
+
+// Convenience method for creating two switches connected to each other.
 // XXX: note this uses net.Pipe and not a proper TCP conn.
 func MakeSwitchPair(initSwitch func(int, *p2p.Switch) *p2p.Switch) (*p2p.Switch, *p2p.Switch) {
 	// Create two switches that will be interconnected.
@@ -180,4 +267,66 @@ func initSwitchFn(_ int, sw *p2p.Switch) *p2p.Switch {
 	}, true))
 
 	return sw
+}
+
+// newMultiplexTransport returns a tcp connected multiplexed peer
+// using the default MConnConfig. It's a convenience function used
+// for testing.
+func newMultiplexTransport(
+	nodeInfo p2p.NodeInfo,
+	nodeKey p2p.NodeKey,
+) *p2p.MultiplexTransport {
+	return p2p.NewMultiplexTransport(
+		nodeInfo, nodeKey, conn.DefaultMConnConfig(),
+	)
+}
+
+func testNodeInfo(id p2p.ID, name string) p2p.NodeInfo {
+	port := getFreePort()
+	return p2p.DefaultNodeInfo{
+		ProtocolVersion: p2p.NewProtocolVersion(
+			version.P2PProtocol,
+			version.BlockProtocol,
+			0,
+		),
+		DefaultNodeID: id,
+		ListenAddr:    fmt.Sprintf("127.0.0.1:%d", port),
+		Network:       "testing",
+		Version:       "1.2.3-rc0-deadbeef",
+		Channels:      []byte{0x01},
+		Moniker:       name,
+		Other: p2p.DefaultNodeInfoOther{
+			TxIndex:    "on",
+			RPCAddress: fmt.Sprintf("127.0.0.1:%d", port),
+		},
+	}
+}
+
+func testDialer(dialAddr p2p.NetAddress, errc chan error) {
+	var (
+		pv     = ed25519.GenPrivKey()
+		dialer = newMultiplexTransport(
+			testNodeInfo(p2p.PubKeyToID(pv.PubKey()), "host_peer"),
+			p2p.NodeKey{
+				PrivKey: pv,
+			},
+		)
+	)
+
+	_, err := dialer.Dial(dialAddr, p2p.PublicPeerConfig{}.GetConfig())
+	if err != nil {
+		errc <- err
+		return
+	}
+
+	// Signal that the connection was established.
+	errc <- nil
+}
+
+func getFreePort() int {
+	port, err := cmtnet.GetFreePort()
+	if err != nil {
+		panic(err)
+	}
+	return port
 }

--- a/multiplex/pdb_test.go
+++ b/multiplex/pdb_test.go
@@ -1,0 +1,125 @@
+package multiplex
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
+)
+
+// ----------------------------------------------------------------------------
+// cometbft-db PrefixDB implementation benchmarks
+
+func BenchmarkPrefixDBSetKey1K(b *testing.B) {
+	numDatabases := 1000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetPrefixDBTestRoot(b, "test-prefix-db-set-key-1k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+func BenchmarkPrefixDBSetKey2K(b *testing.B) {
+	numDatabases := 2000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetPrefixDBTestRoot(b, "test-prefix-db-set-key-2k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+func BenchmarkPrefixDBSetKey10K(b *testing.B) {
+	numDatabases := 10000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetPrefixDBTestRoot(b, "test-prefix-db-set-key-10k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+func BenchmarkPrefixDBSetKey100K(b *testing.B) {
+	numDatabases := 100000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetPrefixDBTestRoot(b, "test-prefix-db-set-key-100k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+func BenchmarkPrefixDBSetKey1M(b *testing.B) {
+	numDatabases := 1000000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs := ResetPrefixDBTestRoot(b, "test-prefix-db-set-key-1mio", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkDBWrite(b, dbPtrs, numDatabases)
+}
+
+// ----------------------------------------------------------------------------
+// Exported helpers
+
+func ResetPrefixDBTestRoot(
+	t testing.TB,
+	testName string,
+	numDatabases int,
+) (string, []dbm.DB) {
+	// create a unique, concurrency-safe test directory under os.TempDir()
+	rootDir, err := os.MkdirTemp("", testName)
+	if err != nil {
+		panic(err)
+	}
+
+	dbDir, err := os.MkdirTemp(rootDir, "cometbft-prefixdb-*")
+	require.NoError(t, err, "should create database directory in temp directory")
+
+	// Open numDatabases database adapters
+	dbPtrs, err := createTempPrefixDB(t, dbDir, numDatabases)
+	require.NoError(t, err, "should create PrefixDB instances in temp directory")
+
+	return rootDir, dbPtrs
+}
+
+// ----------------------------------------------------------------------------
+
+func createTempPrefixDB(
+	t testing.TB,
+	dbDir string,
+	numDatabases int,
+) ([]dbm.DB, error) {
+	t.Helper()
+
+	// Creates a thread-safe rand instance
+	randomizer := cmtrand.NewRand()
+
+	// Prepares slice of database adapters
+	dbPtrs := make([]dbm.DB, numDatabases)
+	dbType := dbm.BackendType("memdb")
+
+	// Creates one global database
+	db, err := dbm.NewDB("global-db", dbType, dbDir)
+	require.NoError(t, err, "should create new DB instance")
+
+	// Creates many *prefixed* database instances using global db
+	for i := 0; i < numDatabases; i++ {
+		scopeHash := randomizer.Str(8) // random 8 bytes fingerprint
+		pdb := dbm.NewPrefixDB(db, []byte(scopeHash))
+
+		dbPtrs[i] = pdb
+		pdb.Close()
+	}
+
+	return dbPtrs, nil
+}

--- a/multiplex/scope.go
+++ b/multiplex/scope.go
@@ -1,0 +1,186 @@
+package multiplex
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+)
+
+// -----------------------------------------------------------------------------
+// scopeID
+// A private struct to deal with unique pairs of user address and scope.
+
+const (
+	fingerprintSize = 8
+)
+
+// scopeID embeds a string and adds a scope hash
+type scopeID struct {
+	ScopeHash string
+	string
+}
+
+// Hash creates a SHA256 hash of the embedded string part of a scopeID, encodes
+// it in hexadecimal format and returns the uppercase transformed string.
+func (s *scopeID) Hash() string {
+	if len(s.ScopeHash) == 0 {
+		sum256 := tmhash.Sum([]byte(s.string))
+		s.ScopeHash = hex.EncodeToString(sum256)
+	}
+
+	return strings.ToUpper(s.ScopeHash)
+}
+
+// Fingerprint creates an 8-bytes size fingerprint using the SHA256 hash.
+func (s *scopeID) Fingerprint() string {
+	if len(s.ScopeHash) == 0 {
+		s.ScopeHash = s.Hash()
+	}
+
+	hashBytes, _ := hex.DecodeString(s.ScopeHash)
+	fpBytes := hashBytes[:fingerprintSize]
+	return strings.ToUpper(hex.EncodeToString(fpBytes))
+}
+
+// String implements Stringer interface
+func (s *scopeID) String() string {
+	return s.string
+}
+
+// -----------------------------------------------------------------------------
+// ScopeRegistry
+// A registry pattern implementation, searchable by user address and scope.
+
+// UserScopeSet maps user addresses to SHA256 scope hashes
+type UserScopeSet map[string][]string
+
+// UserScopeMap maps user addresses to pairs of scope (cleartext) and scope hash
+type UserScopeMap map[string]map[string]string
+
+// ScopeRegistry wraps searchable scope hashes by user and by user+scope
+type ScopeRegistry struct {
+	ScopeHashes UserScopeSet
+	UsersScopes UserScopeMap
+}
+
+func (r *ScopeRegistry) GetScopeHashes() []string {
+	var allHashes []string
+	for _, scopeHashes := range r.ScopeHashes {
+		allHashes = append(allHashes, scopeHashes...)
+	}
+
+	return allHashes
+}
+
+// GetScopeHashes returns a slice of scope hashes by user address
+func (r *ScopeRegistry) GetScopeHashesByUser(
+	userAddress string,
+) ([]string, error) {
+	if _, ok := r.ScopeHashes[userAddress]; !ok {
+		return []string{}, errors.New("no scope hashes found for user: " + userAddress)
+	}
+
+	return r.ScopeHashes[userAddress], nil
+}
+
+// GetScopeHash returns a scope hash by user address and scope (cleartext)
+func (r *ScopeRegistry) GetScopeHash(
+	userAddress string,
+	scope string,
+) (string, error) {
+	if _, ok := r.UsersScopes[userAddress]; !ok {
+		return "", fmt.Errorf("no scope hashes found for user: %s", userAddress)
+	}
+
+	if _, ok := r.UsersScopes[userAddress][scope]; !ok {
+		return "", fmt.Errorf("no scope '%s' for user: %s", scope, userAddress)
+	}
+
+	return r.UsersScopes[userAddress][scope], nil
+}
+
+func (r *ScopeRegistry) GetAddress(scopeHash string) (string, error) {
+	for userAddress, hashes := range r.ScopeHashes {
+		if slices.Contains(hashes, scopeHash) {
+			return userAddress, nil
+		}
+	}
+
+	return "", fmt.Errorf("no address found for scope hash %s", scopeHash)
+}
+
+// ----------------------------------------------------------------------------
+// Builders
+
+func NewScopeID(userAddress string, scope string) *scopeID {
+	return &scopeID{
+		string: fmt.Sprintf("%s:%s", userAddress, scope),
+	}
+}
+
+func NewScopeIDFromHash(scopeHash string) *scopeID {
+	return &scopeID{
+		ScopeHash: strings.ToUpper(scopeHash),
+	}
+}
+
+func NewScopeIDFromDesc(scopeDesc string) *scopeID {
+	return &scopeID{string: scopeDesc}
+}
+
+// ----------------------------------------------------------------------------
+// Providers
+
+type ScopeHashProvider func(*cmtcfg.UserConfig) (ScopeRegistry, error)
+
+// DefaultScopeHashProvider computes SHA256 hashes by pairing user addresses
+// and arbitrary scopes, separated by `:`, such that every combination of user
+// address and scope can be referred to by a scope hash.
+// This method implementation supports concurrent calls.
+// DefaultScopeHashProvider implements ScopeHashProvider
+func DefaultScopeHashProvider(config *cmtcfg.UserConfig) (ScopeRegistry, error) {
+	if config.Replication == cmtcfg.SingularReplicationMode() {
+		return ScopeRegistry{}, nil
+	}
+
+	cacheableHashProvider := sync.OnceValue(func() ScopeRegistry {
+		registry := ScopeRegistry{}
+		registry.ScopeHashes = UserScopeSet{}
+		registry.UsersScopes = UserScopeMap{}
+
+		for userAddress, scopes := range config.UserScopes {
+			// allocates per-user-scope hash map
+			registry.UsersScopes[userAddress] = map[string]string{}
+
+			// Create SHA256 hashes of the pair of user address and scope
+			var userScopeHashes []string
+			for _, scope := range scopes {
+				scopeId := NewScopeID(userAddress, scope)
+				scopeHash := scopeId.Hash()
+				userScopeHashes = append(userScopeHashes, scopeHash)
+
+				// Builds a per-user-scope map of scope hashes
+				registry.UsersScopes[userAddress][scope] = scopeHash
+			}
+
+			// Builds a per-user slice of scope hashes
+			registry.ScopeHashes[userAddress] = userScopeHashes
+		}
+
+		return registry
+	})
+
+	sRegistry := cacheableHashProvider()
+
+	if config.Replication == cmtcfg.PluralReplicationMode() && len(sRegistry.ScopeHashes) == 0 {
+		return ScopeRegistry{}, errors.New("in plural replication mode, at least one user scope is required")
+	}
+
+	return sRegistry, nil
+}

--- a/multiplex/scope_test.go
+++ b/multiplex/scope_test.go
@@ -1,0 +1,164 @@
+package multiplex
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+	mxtest "github.com/cometbft/cometbft/multiplex/test"
+)
+
+func TestMultiplexScopeIDNewScopeID(t *testing.T) {
+	scopeId := NewScopeID(mxtest.TestUserAddress, mxtest.TestScope)
+	assert.NotEmpty(t, scopeId.String(), "scopeID data should not be empty")
+
+	expectedDesc := fmt.Sprintf("%s:%s", mxtest.TestUserAddress, mxtest.TestScope)
+	assert.Equal(t, expectedDesc, scopeId.String())
+}
+
+func TestMultiplexScopeIDNewScopeIDFromHash(t *testing.T) {
+	scopeId := NewScopeIDFromHash(mxtest.TestScopeHash)
+	assert.NotEmpty(t, scopeId.ScopeHash, "scopeID hash should not be empty")
+
+	expectedHash := mxtest.TestScopeHash
+	assert.Equal(t, expectedHash, scopeId.ScopeHash)
+}
+
+func TestMultiplexScopeIDNewScopeIDFromDesc(t *testing.T) {
+	scopeDesc := fmt.Sprintf("%s:%s", mxtest.TestUserAddress, mxtest.TestScope)
+	scopeId := NewScopeIDFromDesc(scopeDesc)
+	assert.NotEmpty(t, scopeId.String(), "scopeID data should not be empty")
+}
+
+func TestMultiplexScopeIDTestScopeHash(t *testing.T) {
+	scopeId := NewScopeID(mxtest.TestUserAddress, mxtest.TestScope)
+	actualHash := scopeId.Hash()
+
+	assert.NotEmpty(t, actualHash, "scope hash should not be empty")
+	assert.Equal(t, mxtest.TestScopeHash, actualHash)
+}
+
+func TestMultiplexScopeIDTestFingerprint(t *testing.T) {
+	scopeId := NewScopeID(mxtest.TestUserAddress, mxtest.TestScope)
+	actualHash := scopeId.Hash()
+	require.NotEmpty(t, actualHash, "scope hash should not be empty")
+
+	actualFP := scopeId.Fingerprint()
+	require.NotEmpty(t, actualHash, "fingerprint should not be empty")
+	assert.Len(t, actualFP, fingerprintSize*2)
+	assert.Equal(t, actualFP, mxtest.TestScopeHash[:fingerprintSize*2])
+}
+
+func TestMultiplexScopeRegistryGetScopeHashesByUser(t *testing.T) {
+	actualResult, err := testScopeRegistry.GetScopeHashesByUser(mxtest.TestUserAddress)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, actualResult, "scope slice by user should not be empty")
+	assert.Len(t, actualResult, 1)
+}
+
+func TestMultiplexScopeRegistryGetScopeHashesByUserErrorNotExist(t *testing.T) {
+	_, err := testScopeRegistry.GetScopeHashesByUser("incorrect address")
+	assert.Error(t, err)
+}
+
+func TestMultiplexScopeRegistryGetScopeHash(t *testing.T) {
+	actualResult, err := testScopeRegistry.GetScopeHash(mxtest.TestUserAddress, mxtest.TestScope)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, actualResult, "scope hash by user and scope should not be empty")
+	assert.Equal(t, mxtest.TestScopeHash, actualResult)
+}
+
+func TestMultiplexScopeRegistryGetAddress(t *testing.T) {
+	actualResult, err := testScopeRegistry.GetAddress(mxtest.TestScopeHash)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, actualResult, "address by scope hash should not be empty")
+	assert.Equal(t, mxtest.TestUserAddress, actualResult)
+}
+
+func TestMultiplexScopeRegistryGetScopeHashErrorNotExist(t *testing.T) {
+	testCases := map[string]string{
+		"incorrect address":                        "incorrect scope",
+		"other incorrect address":                  "Default",
+		"CC8E6555A3F401FF61DA098F94D325E7041BC43A": "incorrect scope",
+		"FF1410CEEB411E55487701C4FEE65AACE7115DC0": "",
+	}
+
+	for failAddress, failScope := range testCases {
+		_, err := testScopeRegistry.GetScopeHash(failAddress, failScope)
+		assert.Error(t, err)
+	}
+}
+
+func TestMultiplexScopeDefaultScopeHashProvider(t *testing.T) {
+	complexUserConfig := &cmtcfg.UserConfig{
+		Replication: cmtcfg.PluralReplicationMode(),
+		UserScopes: map[string][]string{
+			"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"Default", "Other"},
+			"FF1410CEEB411E55487701C4FEE65AACE7115DC0": {"Default", "ReplChain", "Third", "Fourth", "Fifth"},
+			"BB2B85FABDAF8469F5A0F10AB3C060DE77D409BB": {"Cosmos", "ReplChain", "Default"},
+			"5168FD905426DE2E0DB9990B35075EEC3B184977": {"First", "Second"},
+		},
+	}
+
+	actualRegistry, err := DefaultScopeHashProvider(complexUserConfig)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, actualRegistry.ScopeHashes)
+	assert.NotEmpty(t, actualRegistry.UsersScopes)
+}
+
+func TestMultiplexScopeDefaultScopeHashProviderErrorMinScopes(t *testing.T) {
+	// Plural replication must have minimum one scope
+	complexUserConfig := &cmtcfg.UserConfig{
+		Replication: cmtcfg.PluralReplicationMode(),
+		UserScopes:  map[string][]string{},
+	}
+
+	_, err := DefaultScopeHashProvider(complexUserConfig)
+	assert.Error(t, err)
+}
+
+func TestMultiplexScopeHashProviderBuildsRegistry(t *testing.T) {
+	testCases := map[string][]string{
+		"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {"Default", "Other"},
+		"FF1410CEEB411E55487701C4FEE65AACE7115DC0": {"Default", "ReplChain", "Third", "Fourth", "Fifth"},
+		"BB2B85FABDAF8469F5A0F10AB3C060DE77D409BB": {"Cosmos", "ReplChain", "Default"},
+		"5168FD905426DE2E0DB9990B35075EEC3B184977": {"First", "Second"},
+	}
+
+	for testAddress, testScopes := range testCases {
+		testCase := map[string][]string{}
+		testCase[testAddress] = testScopes
+
+		userConf := &cmtcfg.UserConfig{
+			Replication: cmtcfg.PluralReplicationMode(),
+			UserScopes:  testCase,
+		}
+
+		actualRegistry, err := DefaultScopeHashProvider(userConf)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, actualRegistry.ScopeHashes)
+		assert.NotEmpty(t, actualRegistry.UsersScopes)
+		assert.Contains(t, actualRegistry.ScopeHashes, testAddress)
+		assert.Contains(t, actualRegistry.UsersScopes, testAddress)
+
+		for _, expectedScope := range testScopes {
+			assert.Contains(t, actualRegistry.UsersScopes[testAddress], expectedScope)
+		}
+	}
+}
+
+var testScopeRegistry = ScopeRegistry{
+	ScopeHashes: UserScopeSet{
+		"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {
+			"1A63C0E60122F9BB3DF9EA61C8184ED59C3936CAD1A3B35FA1D3BCA272E3F38B",
+		},
+	},
+	UsersScopes: UserScopeMap{
+		"CC8E6555A3F401FF61DA098F94D325E7041BC43A": {
+			"Default": "1A63C0E60122F9BB3DF9EA61C8184ED59C3936CAD1A3B35FA1D3BCA272E3F38B",
+		},
+	},
+}

--- a/multiplex/state_test.go
+++ b/multiplex/state_test.go
@@ -1,0 +1,99 @@
+package multiplex
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
+	"github.com/cometbft/cometbft/internal/test"
+	sm "github.com/cometbft/cometbft/state"
+	"github.com/cometbft/cometbft/types"
+)
+
+func benchmarkMakeBlock(b *testing.B, dbs []dbm.DB, states []sm.State, numDatabases int) {
+	b.Helper()
+
+	// Creates a thread-safe rand instance
+	randomizer := cmtrand.NewRand()
+
+	b.SetParallelism(numDatabases) // 1 proc per state
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Every iteration should create a block from state
+		for pb.Next() {
+			stateIdx := randomizer.Intn(numDatabases)
+			state := states[stateIdx]
+
+			// we always use the TEST PRIV VALIDATOR
+			proposerAddress := state.Validators.Validators[0].Address
+			stateVersion := state.Version.Consensus
+			block := makeBlock(state, 2, new(types.Commit), proposerAddress)
+
+			// test we set some fields
+			assert.Equal(b, stateVersion, block.Version)
+			assert.Equal(b, proposerAddress, block.ProposerAddress)
+		}
+	})
+}
+
+// ----------------------------------------------------------------------------
+// cometbft-db PrefixDB implementation benchmarks
+
+func BenchmarkStateMakeBlock1K(b *testing.B) {
+	numDatabases := 1000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs, statePtrs := ResetStateTestRoot(b, "test-state-make-block-1k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkMakeBlock(b, dbPtrs, statePtrs, numDatabases)
+}
+
+// ----------------------------------------------------------------------------
+// Exported helpers
+
+func ResetStateTestRoot(t testing.TB, testName string, numDatabases int) (string, []dbm.DB, []sm.State) {
+	t.Helper()
+
+	// Creates many *prefixed* database instances using global db
+	rootDir, dbPtrs := ResetPrefixDBTestRoot(t, "state_", numDatabases)
+
+	// Prepares slice of state machines
+	statePtrs := make([]sm.State, numDatabases)
+
+	// Creates many *prefixed* database instances using global db
+	for i := 0; i < numDatabases; i++ {
+
+		config := test.ResetTestRootWithChainID("state_", "state-chain-"+strconv.Itoa(i))
+
+		stateDb := dbPtrs[i]
+		stateStore := sm.NewStore(stateDb, sm.StoreOptions{
+			DiscardABCIResponses: false,
+		})
+
+		state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+		require.NoError(t, err, "expected no error on LoadStateFromDBOrGenesisFile")
+
+		statePtrs[i] = state
+	}
+
+	return rootDir, dbPtrs, statePtrs
+}
+
+// ----------------------------------------------------------------------------
+
+func makeBlock(state sm.State, height int64, c *types.Commit, proposerAddress types.Address) *types.Block {
+	return state.MakeBlock(
+		height,
+		[]types.Tx{},
+		c,
+		nil,
+		proposerAddress,
+	)
+}

--- a/multiplex/state_test.go
+++ b/multiplex/state_test.go
@@ -55,6 +55,40 @@ func BenchmarkStateMakeBlock1K(b *testing.B) {
 	benchmarkMakeBlock(b, dbPtrs, statePtrs, numDatabases)
 }
 
+func BenchmarkStateMakeBlock2K(b *testing.B) {
+	numDatabases := 2000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs, statePtrs := ResetStateTestRoot(b, "test-state-make-block-2k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkMakeBlock(b, dbPtrs, statePtrs, numDatabases)
+}
+
+func BenchmarkStateMakeBlock10K(b *testing.B) {
+	numDatabases := 10000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs, statePtrs := ResetStateTestRoot(b, "test-state-make-block-10k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkMakeBlock(b, dbPtrs, statePtrs, numDatabases)
+}
+
+// CAUTION: This benchmark currently breaks due to a time limitation (for benchtime=30s).
+func BenchmarkStateMakeBlock100K(b *testing.B) {
+	numDatabases := 100000
+
+	// Reset benchmark fs
+	rootDir, dbPtrs, statePtrs := ResetStateTestRoot(b, "test-state-make-block-100k", numDatabases)
+	defer os.RemoveAll(rootDir)
+
+	// Runs b.RunParallel() with GOMAXPROCS=numDatabases
+	benchmarkMakeBlock(b, dbPtrs, statePtrs, numDatabases)
+}
+
 // ----------------------------------------------------------------------------
 // Exported helpers
 

--- a/multiplex/state_test.go
+++ b/multiplex/state_test.go
@@ -42,7 +42,7 @@ func benchmarkMakeBlock(b *testing.B, dbs []dbm.DB, states []sm.State, numDataba
 }
 
 // ----------------------------------------------------------------------------
-// cometbft-db PrefixDB implementation benchmarks
+// cometbft State implementation benchmarks
 
 func BenchmarkStateMakeBlock1K(b *testing.B) {
 	numDatabases := 1000

--- a/multiplex/test/config.go
+++ b/multiplex/test/config.go
@@ -1,0 +1,370 @@
+package test
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	cmtos "github.com/cometbft/cometbft/internal/os"
+	cmttest "github.com/cometbft/cometbft/internal/test"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	"github.com/cometbft/cometbft/privval"
+)
+
+func ResetMultiplexPrivValidator(
+	cfg config.BaseConfig,
+	userAddress string,
+	scope string,
+	privValidator *privval.FilePV,
+	useDefaultPrivValidator bool,
+) *privval.FilePV {
+
+	scopeHash := CreateScopeHash(fmt.Sprintf("%s:%s", userAddress, scope))
+	scopeFingerprint := CreateFingerprint(scopeHash)
+
+	userConfDir := filepath.Join(cfg.RootDir, config.DefaultConfigDir, userAddress)
+	userDataDir := filepath.Join(cfg.RootDir, config.DefaultDataDir, userAddress)
+
+	folderName := scopeFingerprint
+	privValKeyDir := filepath.Join(userConfDir, folderName)
+	privValStateDir := filepath.Join(userDataDir, folderName)
+
+	privValKeyFile := filepath.Join(privValKeyDir, filepath.Base(cfg.PrivValidatorKeyFile()))
+	privValStateFile := filepath.Join(privValStateDir, filepath.Base(cfg.PrivValidatorStateFile()))
+
+	// fmt.Printf("Resetting priv validator key file: %s\n", privValKeyFile)
+	// fmt.Printf("Resetting priv validator state file: %s\n", privValStateFile)
+
+	if useDefaultPrivValidator {
+		// XXX careful this uses always the same priv validator, if a change is made to
+		//     it, please also update the genesis.validators option.
+		cmttest.ResetTestPrivValidatorFiles(privValKeyFile, privValStateFile)
+		return privval.LoadFilePV(privValKeyFile, privValStateFile)
+	}
+
+	// Not using default priv validator, we will either generate a random
+	// new priv validator key, or use the one provided with privValidator
+	filePV := &privval.FilePV{}
+
+	if privValidator == nil {
+		// IMPORTANT: This generates a random privValidator private key
+		filePV = privval.GenFilePV(privValKeyFile, privValStateFile)
+	} else {
+		filePV = privValidator
+	}
+
+	testPrivValidatorKey, _ := cmtjson.MarshalIndent(filePV.Key, "", "  ")
+	cmtos.MustWriteFile(privValKeyFile, []byte(testPrivValidatorKey), 0o644)
+
+	// We always reset priv validator state to 0-height
+	cmtos.MustWriteFile(privValStateFile, []byte(testPrivValidatorState), 0o644)
+
+	return filePV
+}
+
+func ResetTestRootMultiplexDisabled(testName string, chainID string) *config.Config {
+	return cmttest.ResetTestRootWithChainID(testName, chainID)
+}
+
+func ResetTestRootMultiplexWithChainIDAndScopes(
+	testName string,
+	chainID string,
+	userScopes map[string][]string,
+) *config.Config {
+
+	// Calls EnsureRoot() and EnsureRootMultiplex() to reset filesystem
+	baseConfig := resetRootDirWithChainIDAndScopes(testName, chainID, userScopes)
+	rootDir := baseConfig.RootDir
+
+	if chainID == "" {
+		chainID = cmttest.DefaultTestChainID
+	}
+
+	// IMPORTANT:
+	// If there is a genesis file at the configured path, read it and expect it
+	// to contain a genesis doc set ; otherwise create it with testOneScopedGenesisFmt.
+
+	genesisFilePath := filepath.Join(rootDir, baseConfig.Genesis)
+	if !cmtos.FileExists(genesisFilePath) {
+
+		var testGenesis string
+		if len(userScopes) == 0 {
+			testGenesis = fmt.Sprintf(testUserGenesisFmt, TestUserAddress, TestScope, chainID, testDefaultGenesisValidator)
+
+			// We overwrite the default priv validator files
+			cmttest.ResetTestPrivValidator(rootDir, baseConfig)
+		} else {
+			testGenesis = `[`
+			for i, scopeDesc := range baseConfig.GetScopes() {
+				parts := strings.Split(scopeDesc, ":")
+				userAddress, scope := parts[0], parts[1]
+
+				// TODO: Right now, the chainID is forcefully overwritten in loop ; it is
+				// the network owner's responsibility to provide separate chainIDs.
+
+				// Creates one genesis doc per pair of user address and scope
+				perUserChainID := chainID + "-" + strconv.Itoa(i)
+				scopedTestGenesis := fmt.Sprintf(testOneScopedGenesisFmt, userAddress, scope, perUserChainID, testDefaultGenesisValidator)
+				testGenesis += scopedTestGenesis + ","
+
+				// resets priv validators to default state/key (as present in genesis)
+				ResetMultiplexPrivValidator(baseConfig, userAddress, scope, nil, true) // useDefaultPrivValidator=true
+			}
+
+			// Removes last comma and closes json array
+			testGenesis = testGenesis[:len(testGenesis)-1] + `]`
+		}
+
+		cmtos.MustWriteFile(genesisFilePath, []byte(testGenesis), 0o644)
+	}
+
+	// XXX TBI: put singular genesis docs inside scoped subfolders?
+
+	conf := config.MultiplexTestConfig(baseConfig.Replication, userScopes).SetRoot(rootDir)
+	return conf
+}
+
+// CAUTION: Calling this method will create a random priv validator and add it
+// to the validator set that is present in the genesis doc.
+func ResetTestRootMultiplexWithValidators(
+	testName string,
+	chainID string,
+	userScopes map[string][]string, // user_address:[scope1,scope2]
+	validators map[string][]string, // scope_hash:[validator1,validator2]
+	privValidator *privval.FilePV, // use nil to use default or generate
+	persistentPeers string, // a comma-separated list of peers to keep connection
+) *config.Config {
+
+	// Calls EnsureRoot() and EnsureRootMultiplex() to reset filesystem
+	baseConfig := resetRootDirWithChainIDAndScopes(testName, chainID, userScopes)
+	rootDir := baseConfig.RootDir
+
+	// IMPORTANT:
+	// If there is a genesis file at the configured path, read it and expect it
+	// to contain a genesis doc set ; otherwise create it with testOneScopedGenesisFmt.
+
+	genesisFilePath := filepath.Join(rootDir, baseConfig.Genesis)
+
+	if !cmtos.FileExists(genesisFilePath) {
+		if chainID == "" {
+			chainID = cmttest.DefaultTestChainID
+		}
+		var testGenesis string
+
+		testGenesis = `[`
+
+		for i, scopeDesc := range baseConfig.GetScopes() {
+			parts := strings.Split(scopeDesc, ":")
+			userAddress, scope := parts[0], parts[1]
+			scopeHash := CreateScopeHash(scopeDesc)
+
+			// TODO: Right now, the chainID is forcefully overwritten in loop ; it is
+			// the network owner's responsibility to provide separate chainIDs.
+
+			// Creates one genesis doc per pair of user address and scope
+			perUserChainID := chainID + "-" + strconv.Itoa(i)
+
+			// Resets priv validator to default state (as present in genesis)
+			validatorSet, ok := validators[scopeHash]
+			if !ok {
+				// Resets priv validator to default key
+				fmt.Printf("WARNING: no validators found, fallback to default validator set (%s)\n", scopeHash)
+				validatorSet = []string{testGenesisValidatorPubKey}
+				ResetMultiplexPrivValidator(baseConfig, userAddress, scope, nil, true) // useDefaultPrivValidator=true
+			} else if privValidator == nil {
+				// Resets priv validator to newly generated random key
+				privVal := ResetMultiplexPrivValidator(baseConfig, userAddress, scope, nil, false) // useDefaultPrivValidator=false
+				pvPubKey := base64.StdEncoding.EncodeToString(privVal.Key.PubKey.Bytes())
+				validatorSet = append(validatorSet, pvPubKey)
+			} else /* privValidator != nil */ {
+				// Resets priv validator to specific key
+				// IMPORTANT: we won't add it to the validator set as it should be already present
+				ResetMultiplexPrivValidator(baseConfig, userAddress, scope, privValidator, false) // useDefaultPrivValidator=false
+			}
+
+			validatorsJSON := ""
+			for i, validatorPubKey := range validatorSet {
+				validatorsJSON += fmt.Sprintf(testValidatorFmt, validatorPubKey, 10) // 10=voting power
+				if i < len(validatorSet)-1 {
+					validatorsJSON += ", "
+				}
+			}
+
+			scopedTestGenesis := fmt.Sprintf(testOneScopedGenesisFmt, userAddress, scope, perUserChainID, validatorsJSON)
+			testGenesis += scopedTestGenesis + ","
+		}
+
+		// Removes last comma and closes json array
+		testGenesis = testGenesis[:len(testGenesis)-1] + `]`
+		cmtos.MustWriteFile(genesisFilePath, []byte(testGenesis), 0o644)
+	}
+
+	// XXX TBI: put singular genesis docs inside scoped subfolders?
+
+	conf := config.MultiplexTestConfig(baseConfig.Replication, userScopes).SetRoot(rootDir)
+
+	// XXX this should be scoped
+	if len(persistentPeers) > 0 {
+		conf.P2P.PersistentPeers = persistentPeers
+	}
+
+	return conf
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+
+func CreateScopeHash(scopeDesc string) string {
+	sum256 := tmhash.Sum([]byte(scopeDesc))
+	return strings.ToUpper(hex.EncodeToString(sum256))
+}
+
+func CreateFingerprint(scopeHash string) string {
+	hashBytes, _ := hex.DecodeString(scopeHash)
+	return strings.ToUpper(hex.EncodeToString(hashBytes[:8]))
+}
+
+func GeneratePrivValidators(testName string, numValidators int) []*privval.FilePV {
+	tempDir, err := os.MkdirTemp("", "priv-validators-"+testName)
+	if err != nil {
+		panic(err)
+	}
+
+	privVals := make([]*privval.FilePV, numValidators)
+	for i := 0; i < numValidators; i++ {
+		indexPrivVal := strconv.Itoa(i)
+		privValKeyFile := filepath.Join(tempDir, indexPrivVal+"_priv_validator_key.json")
+		privValStateFile := filepath.Join(tempDir, indexPrivVal+"_priv_validator_state.json")
+
+		filePV := privval.LoadOrGenFilePV(privValKeyFile, privValStateFile)
+		privVals[i] = filePV
+	}
+
+	os.RemoveAll(tempDir)
+	return privVals
+}
+
+// ----------------------------------------------------------------------------
+// Private helpers
+
+func resetRootDirWithChainIDAndScopes(
+	testName string,
+	chainID string,
+	userScopes map[string][]string,
+) config.BaseConfig {
+	// create a unique, concurrency-safe test directory under os.TempDir()
+	rootDir, err := os.MkdirTemp("", fmt.Sprintf("%s-%s_", chainID, testName))
+	if err != nil {
+		panic(err)
+	}
+
+	config.EnsureRoot(rootDir)
+
+	baseConfig := config.MultiplexBaseConfig(
+		config.PluralReplicationMode(),
+		userScopes,
+	)
+
+	baseConfig.RootDir = rootDir
+
+	// XXX:
+	// This is not optimal as it is possible that undesired config will
+	// be overwritten ; at best we should replace the EnsureRoot call
+	// completely with this one. This solution is for further compat.
+	config.EnsureRootMultiplex(rootDir, &baseConfig)
+	return baseConfig
+}
+
+// ----------------------------------------------------------------------------
+
+// TestScopeHash is a SHA256 of "user_address:scope" with TestUserAddress and scope "Default"
+var TestScopeHash = "1A63C0E60122F9BB3DF9EA61C8184ED59C3936CAD1A3B35FA1D3BCA272E3F38B"
+var TestFolderName = "1A63C0E60122F9BB" // fingerprint of TestScopeHash
+var TestScope = "Default"
+var TestUserAddress = "CC8E6555A3F401FF61DA098F94D325E7041BC43A"
+var testUserGenesisFmt = `[` + testOneScopedGenesisFmt + `]`
+var testOneScopedGenesisFmt = `{
+	"user_address": "%s",
+	"scope": "%s",
+	"genesis": {
+		"genesis_time": "2018-10-10T08:20:13.695936996Z",
+		"chain_id": "%s",
+		"initial_height": "1",
+		"consensus_params": {
+			"block": {
+				"max_bytes": "22020096",
+				"max_gas": "-1",
+				"time_iota_ms": "10"
+			},
+			"synchrony": {
+				"message_delay": "500000000",
+				"precision": "10000000"
+			},
+			"evidence": {
+				"max_age_num_blocks": "100000",
+				"max_age_duration": "172800000000000",
+				"max_bytes": "1048576"
+			},
+			"validator": {
+				"pub_key_types": [
+					"ed25519"
+				]
+			},
+			"abci": {
+				"vote_extensions_enable_height": "0"
+			},
+			"version": {},
+			"feature": {
+				"vote_extensions_enable_height": "0",
+				"pbts_enable_height": "1"
+			}
+		},
+		"validators": [
+			%s
+		],
+		"app_hash": ""
+	}
+}`
+
+var testGenesisValidatorPubKey = "AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="
+var testDefaultGenesisValidator = `{
+	"pub_key": {
+		"type": "tendermint/PubKeyEd25519",
+		"value":"` + testGenesisValidatorPubKey + `"
+	},
+	"power": "10",
+	"name": ""
+}`
+
+var testValidatorFmt = `{
+	"pub_key": {
+		"type": "tendermint/PubKeyEd25519",
+		"value":"%s"
+	},
+	"power": "%d",
+	"name": ""
+}`
+
+var testPrivValidatorKeyFmt = `{
+  "address": "%s",
+  "pub_key": {
+    "type": "tendermint/PubKeyEd25519",
+    "value": "%s"
+  },
+  "priv_key": {
+    "type": "tendermint/PrivKeyEd25519",
+    "value": "%s"
+  }
+}`
+
+var testPrivValidatorState = `{
+  "height": "0",
+  "round": 0,
+  "step": 0
+}`

--- a/multiplex/wal.go
+++ b/multiplex/wal.go
@@ -1,0 +1,51 @@
+package multiplex
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	auto "github.com/cometbft/cometbft/internal/autofile"
+	cs "github.com/cometbft/cometbft/internal/consensus"
+	cmtos "github.com/cometbft/cometbft/internal/os"
+	"github.com/cometbft/cometbft/libs/service"
+)
+
+const (
+	// how often the WAL should be sync'd during period sync'ing.
+	mxWalDefaultFlushInterval = 10 * 2 * time.Second
+)
+
+type ScopedWAL struct {
+	ScopeHash string
+	*cs.BaseWAL
+}
+
+var _ cs.WAL = &ScopedWAL{}
+
+// NewScopedWAL returns a new write-ahead logger based on `baseWAL`, which implements
+// WAL. It's flushed and synced to disk every 20s and once when stopped.
+func NewScopedWAL(walFiles map[string]string, groupOptions ...func(*auto.Group)) (*MultiplexWAL, error) {
+	multiplexWAL := make(MultiplexWAL, len(walFiles))
+	for scopeHash, walFile := range walFiles {
+		err := cmtos.EnsureDir(filepath.Dir(walFile), 0o700)
+		if err != nil {
+			return nil, fmt.Errorf("failed to ensure WAL directory is in place: %w", err)
+		}
+
+		// XXX head file is opened, i.e. bottleneck with > 10k files
+		group, err := OpenScopedGroup(scopeHash, walFile, groupOptions...)
+		if err != nil {
+			return nil, err
+		}
+		wal := &ScopedWAL{
+			ScopeHash: scopeHash,
+			BaseWAL:   cs.NewWALWithParams(group.Group, cs.NewWALEncoder(group), mxWalDefaultFlushInterval),
+		}
+
+		wal.BaseService = *service.NewBaseService(nil, "baseWAL", wal)
+		multiplexWAL[scopeHash] = wal
+	}
+
+	return &multiplexWAL, nil
+}

--- a/multiplex/wal.go
+++ b/multiplex/wal.go
@@ -16,6 +16,7 @@ const (
 	mxWalDefaultFlushInterval = 10 * 2 * time.Second
 )
 
+// ScopedWAL embeds a BaseWAL and adds a scope hash
 type ScopedWAL struct {
 	ScopeHash string
 	*cs.BaseWAL

--- a/multiplex/wal_test.go
+++ b/multiplex/wal_test.go
@@ -232,6 +232,7 @@ func createTempWalFiles(
 		require.NoError(t, err, "should create new WAL instance")
 
 		walPtrs[i] = wal
+		walFile.Close() // no need to keep open
 	}
 
 	return walFiles, walPtrs, nil

--- a/multiplex/wal_test.go
+++ b/multiplex/wal_test.go
@@ -1,0 +1,157 @@
+package multiplex
+
+import (
+	"encoding/hex"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/merkle"
+	"github.com/cometbft/cometbft/internal/autofile"
+	cs "github.com/cometbft/cometbft/internal/consensus"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
+	cmttypes "github.com/cometbft/cometbft/types"
+)
+
+// ----------------------------------------------------------------------------
+// Benchmarks
+
+func benchmarkWalWrite(b *testing.B, wals []*cs.BaseWAL, data cs.WALMessage, numWalFiles int) {
+	b.Helper()
+
+	// Creates a thread-safe rand instance
+	randomizer := cmtrand.NewRand()
+
+	b.SetParallelism(numWalFiles) // 1 proc per WAL file
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Every iteration should perform a write in WAL
+		for pb.Next() {
+			// cmtrand is thread-safe
+			walIdx := randomizer.Intn(numWalFiles)
+			wals[walIdx].Write(data)
+		}
+	})
+}
+
+func BenchmarkMultiwalFilesWriteRaw1K(b *testing.B) {
+	numWalFiles := 1000
+
+	// Reset benchmark fs
+	rootDir, _, walPtrs := ResetMultiwalTestRoot(b, "test-multi-wal-files-write-1k", numWalFiles)
+	defer os.RemoveAll(rootDir)
+
+	// Mocks an 8-byte WAL raw message
+	data, _ := hex.DecodeString("0102030405060708")
+
+	// Runs b.RunParallel() with GOMAXPROCS=numWalFiles
+	benchmarkWalWrite(b, walPtrs, cs.WALMessage(data), numWalFiles)
+}
+
+func BenchmarkMultiwalFilesWriteRaw2K(b *testing.B) {
+	numWalFiles := 2000
+
+	// Reset benchmark fs
+	rootDir, _, walPtrs := ResetMultiwalTestRoot(b, "test-multi-wal-files-write-2k", numWalFiles)
+	defer os.RemoveAll(rootDir)
+
+	// Mocks an 8-byte WAL raw message
+	data, _ := hex.DecodeString("0102030405060708")
+
+	// Runs b.RunParallel() with GOMAXPROCS=numWalFiles
+	benchmarkWalWrite(b, walPtrs, cs.WALMessage(data), numWalFiles)
+}
+
+// CAUTION: This benchmark currently breaks due to a too high amount of WAL files
+func BenchmarkMultiwalFilesWriteRaw10K(b *testing.B) {
+	numWalFiles := 10000
+
+	// Reset benchmark fs
+	rootDir, _, walPtrs := ResetMultiwalTestRoot(b, "test-multi-wal-files-write-10k", numWalFiles)
+	defer os.RemoveAll(rootDir)
+
+	// Mocks an 8-byte WAL raw message
+	data, _ := hex.DecodeString("0102030405060708")
+
+	// Runs b.RunParallel() with GOMAXPROCS=numWalFiles
+	benchmarkWalWrite(b, walPtrs, cs.WALMessage(data), numWalFiles)
+}
+
+func BenchmarkMultiwalFilesWriteBlock1K(b *testing.B) {
+	numWalFiles := 1000
+
+	// Reset benchmark fs
+	rootDir, _, walPtrs := ResetMultiwalTestRoot(b, "test-multi-wal-files-write-2k", numWalFiles)
+	defer os.RemoveAll(rootDir)
+
+	// Mocks a block part message with 8 bytes 0-message
+	data := &cs.BlockPartMessage{
+		Height: 1,
+		Round:  1,
+		Part: &cmttypes.Part{
+			Index: 1,
+			Bytes: make([]byte, 1),
+			Proof: merkle.Proof{
+				Total:    1,
+				Index:    1,
+				LeafHash: make([]byte, 8), // 8-bytes 0 message
+			},
+		},
+	}
+
+	// Runs b.RunParallel() with GOMAXPROCS=numWalFiles
+	benchmarkWalWrite(b, walPtrs, data, numWalFiles)
+}
+
+// ----------------------------------------------------------------------------
+// Exported helpers
+
+func ResetMultiwalTestRoot(
+	t testing.TB,
+	testName string,
+	numWalFiles int,
+) (string, []string, []*cs.BaseWAL) {
+	// create a unique, concurrency-safe test directory under os.TempDir()
+	rootDir, err := os.MkdirTemp("", testName)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create numWalFiles .wal files in temp and create cs.WAL instances
+	walFiles, walPtrs, err := createTempWalFiles(t, rootDir, numWalFiles)
+	require.NoError(t, err, "should create wal files in temp directory")
+
+	return rootDir, walFiles, walPtrs
+}
+
+// ----------------------------------------------------------------------------
+
+// Note: This helper does not start the WAL service
+func createTempWalFiles(
+	t testing.TB,
+	rootDir string,
+	numWalFiles int,
+) ([]string, []*cs.BaseWAL, error) {
+	t.Helper()
+
+	walPtrs := make([]*cs.BaseWAL, numWalFiles)
+	walFiles := make([]string, numWalFiles)
+	for i := 0; i < numWalFiles; i++ {
+		walFile, err := os.CreateTemp(rootDir, "*.wal")
+		if err != nil {
+			return walFiles, walPtrs, err
+		}
+
+		wal, err := cs.NewWAL(walFile.Name(),
+			autofile.GroupCheckDuration(60*time.Second),
+			autofile.GroupHeadSizeLimit(100*1024*1024), // 100M
+		)
+		require.NoError(t, err, "should create new WAL instance")
+
+		walPtrs[i] = wal
+	}
+
+	return walFiles, walPtrs, nil
+}


### PR DESCRIPTION
#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec

<a id="open-issues">&nbsp;</a>
##### Open Issues

- [ ] 100k files benchmark currently breaks due to file descriptors system limits.
- [x] TBI: 100k databases benchmark (memdb) currently breaks due to cometbft-db bottleneck(s).
- [ ] `NewScopedWAL` opens too many file descriptors at once, TBI using waitgroup or semaphore.

##### Notes

- The `ScopedWAL` implementation overwrites the `walDefaultFlushInterval` duration.
- A local change is necessary in `internal/autofile.go` to disable *close on SIGHUP* (parallelism to be fixed).
- A local change is necessary in `internal/group.go` to loosen the autofile close period bottlenecks.
- Contains benchmarks that write `EventRoundState` messages in  (1k, 2k, 10k) concurrent WAL files
- Contains benchmarks that write a key-value pair in (1k, 2k, 10k, 100k) concurrent databases (MemDB).
- Contains benchmarks that write a key-value pair in (1k, 2k, 10k, 100k) concurent *prefixed* databases (PrefixDB).
- Benchmarking results can be found [here](#benchmark-results).
- Work in progress or "local" changes can be found [here](#work-in-progress).
- Identified several bottlenecks in autofile and Group implementation:
  - `autofile` closing strategy, closePeriod default is 1s
  - `autofile`'s SIGHUP closing feature is not concurrency-safe 
  - `Group` rotation strategy, default head size limit 10M (already big)
  - `Group` rotation strategy with colocated WAL files grows directory tree
  - `Group.readGroupInfo` iterates through *all* directory files
- Observations with regards to the usage of `PrefixDB` are:
  - Negatives:
    - It allows *less parallel operations* than the traditional database adapters.
    - Performance impact is relatively big due to prefixing strategy, i.e. prefixes on every "Set".
      - avg. 10mio operations for PrefixDB vs. 80 mio operations for MemDB.
  - Positives:
    - It is **thread-safe** and it is compatible with opening 100k concurrent prefixed databases.
    - Runtime opens much less file descriptors which has a positive impact on allocated resources.

##### Commands

```bash
# run benchmark suite for legacy BaseWAL implementation
# `-run=xxx` disables unit test executions because they would interfere with benchmarks
go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiwal.* -run=xxx

# run benchmark suite for custom MultiplexWAL implementation
# `-run=xxx` disables unit test executions because they would interfere with benchmarks
go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiplex.* -run=xxx

# run benchmark suite for cometbft-db MemDB implementation
# `-run=xxx` disables unit test executions because they would interfere with benchmarks
go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiDB.* -run=xxx

# run benchmark suite for cometbft-db PrefixDB implementation
# `-run=xxx` disables unit test executions because they would interfere with benchmarks
go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkPrefixDB.* -run=xxx
```

<a id="benchmark-results">&nbsp;</a>
##### Benchmark results

1.0. **Benchmark for legacy WAL implementation (BaseWAL)**

```bash
### 1000 WAL files (+- 60 seconds)
$ go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiwalFilesWriteRaw1K -run=xxx -benchmem -benchtime=30s

(cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz)
BenchmarkMultiwalFilesWriteRaw1K-8   	 6096062	       431.0 ns/op	     144 B/op	       4 allocs/op
BenchmarkMultiwalFilesWriteRaw1K-8   	 6169886	       361.4 ns/op	     144 B/op	       4 allocs/op
BenchmarkMultiwalFilesWriteRaw1K-8   	 6419258	       332.9 ns/op	     144 B/op	       4 allocs/op
BenchmarkMultiwalFilesWriteRaw1K-8   	 6490659	       411.6 ns/op	     144 B/op	       4 allocs/op

### 2000 WAL files (+- 240 seconds)
$ go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiwalFilesWriteRaw2K -run=xxx -benchmem -benchtime=30s

(cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz)
BenchmarkMultiwalFilesWriteRaw2K-8   	 5561179	       426.4 ns/op	     144 B/op	       4 allocs/op
BenchmarkMultiwalFilesWriteRaw2K-8   	 5422630	       478.8 ns/op	     144 B/op	       4 allocs/op
BenchmarkMultiwalFilesWriteRaw2K-8   	 4284630	       481.5 ns/op	     145 B/op	       4 allocs/op
BenchmarkMultiwalFilesWriteRaw2K-8   	 5250862	       539.1 ns/op	     144 B/op	       4 allocs/op

### NOTE: 10000 WAL files is not testable due to bottleneck in autofile
```

2.0. **Benchmark for multiplex WAL implementation (MultiplexWAL)**

```bash
### 1000 WAL files (+- 80 seconds)
$ go test github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiplexWALFilesWriteRaw1K -run=xxx -benchmem -benchtime=30s

(cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz)
BenchmarkMultiplexWALFilesWriteRaw1K-8   	78904678	       663.7 ns/op	     305 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw1K-8   	65791575	       654.3 ns/op	     305 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw1K-8   	60489222	       587.8 ns/op	     305 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw1K-8   	78120382	       582.9 ns/op	     305 B/op	       9 allocs/op

### 2000 WAL files (+- 80 seconds)
$ go test github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiplexWALFilesWriteRaw2K -run=xxx -benchmem -benchtime=30s

(cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz)
BenchmarkMultiplexWALFilesWriteRaw2K-8   	82839333	       476.1 ns/op	     305 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw2K-8   	83176502	       534.7 ns/op	     305 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw2K-8   	83067416	       538.2 ns/op	     305 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw2K-8   	69080337	       550.6 ns/op	     305 B/op	       9 allocs/op

### 10000 WAL files (+- 120 seconds)
$ go test github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiplexWALFilesWriteRaw10K -run=xxx -benchmem -benchtime=30s

(cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz)
BenchmarkMultiplexWALFilesWriteRaw10K-8   	29237996	      1991 ns/op	     307 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw10K-8   	41737461	      1642 ns/op	     306 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw10K-8   	17414515	      2431 ns/op	     308 B/op	       9 allocs/op
BenchmarkMultiplexWALFilesWriteRaw10K-8   	15086642	      2828 ns/op	     307 B/op	       9 allocs/op
```

3.0 **Benchmark for cometbft-db MemDB implementation with concurrent database write operations**

```bash
### 1000 databases (+- 60 seconds)
$ go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiDBSetKey1K -run=xxx -benchmem -benchtime=30s

BenchmarkMultiDBSetKey1K-8   	104702586	       387.4 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey1K-8   	88470571	       384.9 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey1K-8   	91062960	       402.6 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey1K-8   	96174459	       398.7 ns/op	      48 B/op	       1 allocs/op

### 2000 databases (+- 60 seconds)
$ go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiDBSetKey2K -run=xxx -benchmem -benchtime=30s

BenchmarkMultiDBSetKey2K-8   	94320037	       443.0 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey2K-8   	79056361	       443.1 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey2K-8   	92559890	       463.4 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey2K-8   	86945485	       460.7 ns/op	      48 B/op	       1 allocs/op

### 10000 databases (+- 80 seconds)
$ go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiDBSetKey10K -run=xxx -benchmem -benchtime=30s

BenchmarkMultiDBSetKey10K-8   	74290812	       660.0 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey10K-8   	72961462	       565.7 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey10K-8   	63309657	       506.5 ns/op	      48 B/op	       1 allocs/op
BenchmarkMultiDBSetKey10K-8   	66698498	       533.3 ns/op	      48 B/op	       1 allocs/op

### 100000 databases (+- 180 seconds)
### NOTE: 100k databases randomly breaks (errors) due to potential bottleneck in cometbft-db MemDB (TBI)
$ go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkMultiDBSetKey100K -run=xxx -benchmem -benchtime=30s

BenchmarkMultiDBSetKey100K-3    54933896               612.8 ns/op            49 B/op          1 allocs/op
BenchmarkMultiDBSetKey100K-3    50897419               651.0 ns/op            49 B/op          1 allocs/op
```

4.0 **Benchmark for cometbft-db PrefixDB implementation with concurrent database write operations**

```bash
### 1000 databases (+- 30 seconds)
go test -p 1 github.com/cometbft/cometbft/multiplex -bench BenchmarkPrefixDBSetKey1K -run=xxx -benchmem -benchtime=30s

BenchmarkPrefixDBSetKey1K-8   	30300864	      1252 ns/op	      72 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey1K-8   	26225466	      1775 ns/op	      72 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey1K-8   	25655677	      1571 ns/op	      72 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey1K-8   	30186188	      1211 ns/op	      72 B/op	       3 allocs/op

### 2000 databases (+- 30 seconds)
BenchmarkPrefixDBSetKey2K-8   	23888715	      1544 ns/op	      72 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey2K-8   	22909471	      1712 ns/op	      72 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey2K-8   	26928771	      1397 ns/op	      72 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey2K-8   	26889001	      1448 ns/op	      72 B/op	       3 allocs/op

### 10000 databases (+- 40 seconds)
BenchmarkPrefixDBSetKey10K-8   	11753448	      2621 ns/op	      73 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey10K-8   	19574010	      1726 ns/op	      73 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey10K-8   	18775554	      2292 ns/op	      72 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey10K-8   	15769294	      2166 ns/op	      72 B/op	       3 allocs/op

### 100000 databases (+- 60 seconds)
BenchmarkPrefixDBSetKey100K-8   	11276200	      3338 ns/op	      81 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey100K-8   	10563115	      3798 ns/op	      81 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey100K-8   	 8843582	      3882 ns/op	      83 B/op	       3 allocs/op
BenchmarkPrefixDBSetKey100K-8   	 9986694	      3360 ns/op	      82 B/op	       3 allocs/op
```